### PR TITLE
Fix @Serializable to LoginScreenKey to prevent navigation crash

### DIFF
--- a/app/src/main/java/com/example/twdist_android/core/ui/navigation/NavigationRoot.kt
+++ b/app/src/main/java/com/example/twdist_android/core/ui/navigation/NavigationRoot.kt
@@ -33,7 +33,7 @@ data object MoreScreenKey : AppScreen
 
 @Serializable
 data object RegisterScreenKey : AppScreen
-
+@Serializable
 data object LoginScreenKey : AppScreen
 
 @Composable


### PR DESCRIPTION
This pull request makes a minor update to the navigation keys in the app. The change ensures that the `LoginScreenKey` data object is marked as `Serializable`, which is necessary for proper serialization and navigation handling in Jetpack Compose.

- Added the `Serializable` annotation to the `LoginScreenKey` data object in `NavigationRoot.kt` to enable serialization for navigation.