### PR TITLE
Feat/delete project

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,6 +67,7 @@ kapt {
 
 dependencies {
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.recyclerview)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))

--- a/app/src/main/java/com/example/twdist_android/di/ExploreModule.kt
+++ b/app/src/main/java/com/example/twdist_android/di/ExploreModule.kt
@@ -6,6 +6,7 @@ import com.example.twdist_android.features.explore.data.store.inmemory.InMemoryP
 import com.example.twdist_android.features.explore.domain.repository.ProjectRepository
 import com.example.twdist_android.features.explore.domain.store.ProjectStateStore
 import com.example.twdist_android.features.explore.application.usecases.CreateProjectUseCase
+import com.example.twdist_android.features.explore.application.usecases.DeleteProjectUseCase
 import com.example.twdist_android.features.explore.application.usecases.GetProjectsUseCase
 import dagger.Module
 import dagger.Provides
@@ -43,4 +44,12 @@ object ExploreModule {
         projectStateStore: ProjectStateStore
     ): CreateProjectUseCase =
         CreateProjectUseCase(repository, projectStateStore)
+
+    @Provides
+    @Singleton
+    fun provideDeleteProjectUseCase(
+        repository: ProjectRepository,
+        projectStateStore: ProjectStateStore
+    ): DeleteProjectUseCase =
+        DeleteProjectUseCase(repository, projectStateStore)
 }

--- a/app/src/main/java/com/example/twdist_android/features/explore/application/usecases/DeleteProjectUseCase.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/application/usecases/DeleteProjectUseCase.kt
@@ -1,0 +1,15 @@
+package com.example.twdist_android.features.explore.application.usecases
+
+import com.example.twdist_android.features.explore.domain.repository.ProjectRepository
+import com.example.twdist_android.features.explore.domain.store.ProjectStateStore
+import javax.inject.Inject
+
+class DeleteProjectUseCase @Inject constructor(
+    private val repository: ProjectRepository,
+    private val projectStateStore: ProjectStateStore
+) {
+    suspend operator fun invoke(projectId: Long): Result<Unit> {
+        return repository.deleteProject(projectId)
+            .onSuccess { projectStateStore.remove(projectId) }
+    }
+}

--- a/app/src/main/java/com/example/twdist_android/features/explore/data/remote/ExploreApi.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/data/remote/ExploreApi.kt
@@ -3,9 +3,12 @@ package com.example.twdist_android.features.explore.data.remote
 import com.example.twdist_android.features.explore.data.dto.CreateProjectRequestDto
 import com.example.twdist_android.features.explore.data.dto.ProjectResponseDto
 import com.example.twdist_android.features.explore.data.dto.ProjectSummaryDto
+import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.Path
 
 interface ExploreApi {
     @GET("projects/get")
@@ -15,4 +18,7 @@ interface ExploreApi {
     suspend fun createProject(
         @Body request: CreateProjectRequestDto
     ): ProjectResponseDto
+
+    @DELETE("projects/{projectId}/delete")
+    suspend fun deleteProject(@Path("projectId") projectId: Long): Response<Unit>
 }

--- a/app/src/main/java/com/example/twdist_android/features/explore/data/repository/ProjectRepositoryImpl.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/data/repository/ProjectRepositoryImpl.kt
@@ -11,6 +11,7 @@ import com.example.twdist_android.features.explore.domain.model.ProjectSummary
 import com.example.twdist_android.features.explore.domain.repository.ProjectRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import retrofit2.HttpException
 import javax.inject.Inject
 
 class ProjectRepositoryImpl @Inject constructor(
@@ -35,6 +36,17 @@ class ProjectRepositoryImpl @Inject constructor(
             withContext(Dispatchers.IO) {
                 val request = CreateProjectRequestDto(name = projectName.asString())
                 api.createProject(request).toDomainResponse().getOrThrow()
+            }
+        }
+    }
+
+    override suspend fun deleteProject(projectId: Long): Result<Unit> {
+        return runSuspendCatching {
+            withContext(Dispatchers.IO) {
+                val response = api.deleteProject(projectId)
+                if (!response.isSuccessful) {
+                    throw HttpException(response)
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/twdist_android/features/explore/domain/repository/ProjectRepository.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/domain/repository/ProjectRepository.kt
@@ -7,4 +7,5 @@ import com.example.twdist_android.features.explore.domain.model.ProjectSummary
 interface ProjectRepository {
     suspend fun getAllProjects(): Result<List<ProjectSummary>>
     suspend fun createProject(projectName: ProjectName): Result<Project>
+    suspend fun deleteProject(projectId: Long): Result<Unit>
 }

--- a/app/src/main/java/com/example/twdist_android/features/explore/presentation/components/DeleteProjectDialog.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/presentation/components/DeleteProjectDialog.kt
@@ -1,0 +1,33 @@
+package com.example.twdist_android.features.explore.presentation.components
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import com.example.twdist_android.features.explore.presentation.model.ProjectUi
+
+@Composable
+fun DeleteProjectDialog(
+    project: ProjectUi,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Delete project") },
+        text = {
+            Text("Delete \"${project.name}\"? This cannot be undone.")
+        },
+        confirmButton = {
+            Button(onClick = onConfirm) {
+                Text("Delete")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/example/twdist_android/features/explore/presentation/components/ProjectListRecycler.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/presentation/components/ProjectListRecycler.kt
@@ -1,0 +1,72 @@
+package com.example.twdist_android.features.explore.presentation.components
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.recyclerview.widget.ItemTouchHelper
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.example.twdist_android.features.explore.presentation.components.recyclerview.ProjectListRecyclerAdapter
+import com.example.twdist_android.features.explore.presentation.components.recyclerview.ProjectRowColors
+import com.example.twdist_android.features.explore.presentation.components.recyclerview.ProjectSwipeDeleteCallback
+import com.example.twdist_android.features.explore.presentation.model.ProjectUi
+
+private class ProjectListRecyclerInteraction {
+    var onProjectClick: (ProjectUi) -> Unit = {}
+    var onStarClick: (ProjectUi) -> Unit = {}
+    var onSwipeDeleteThreshold: (Long) -> Unit = {}
+}
+
+@Composable
+fun ProjectListRecycler(
+    projects: List<ProjectUi>,
+    onProjectClick: (ProjectUi) -> Unit,
+    onStarClick: (ProjectUi) -> Unit,
+    onSwipeDeleteThreshold: (Long) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val deleteLabel = "Delete"
+    val scheme = MaterialTheme.colorScheme
+    val rowColors = ProjectRowColors(
+        surfaceVariant = scheme.surfaceVariant.toArgb(),
+        primary = scheme.primary.toArgb(),
+        onSurface = scheme.onSurface.toArgb()
+    )
+    val interaction = remember { ProjectListRecyclerInteraction() }
+    SideEffect {
+        interaction.onProjectClick = onProjectClick
+        interaction.onStarClick = onStarClick
+        interaction.onSwipeDeleteThreshold = onSwipeDeleteThreshold
+    }
+    val adapter = remember {
+        ProjectListRecyclerAdapter().also { listAdapter ->
+            listAdapter.onProjectClick = { interaction.onProjectClick(it) }
+            listAdapter.onStarClick = { interaction.onStarClick(it) }
+        }
+    }
+    val swipeCallback = remember {
+        ProjectSwipeDeleteCallback(
+            adapter = adapter,
+            deleteSwipeLabel = "",
+            onSwipeDeleteThreshold = { id -> interaction.onSwipeDeleteThreshold(id) }
+        )
+    }
+    AndroidView(
+        factory = { context ->
+            RecyclerView(context).apply {
+                layoutManager = LinearLayoutManager(context)
+                this.adapter = adapter
+                ItemTouchHelper(swipeCallback).attachToRecyclerView(this)
+            }
+        },
+        update = {
+            swipeCallback.deleteSwipeLabel = deleteLabel
+            adapter.syncListAndColors(projects, rowColors)
+        },
+        modifier = modifier
+    )
+}

--- a/app/src/main/java/com/example/twdist_android/features/explore/presentation/components/recyclerview/ProjectListRecyclerAdapter.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/presentation/components/recyclerview/ProjectListRecyclerAdapter.kt
@@ -1,0 +1,135 @@
+package com.example.twdist_android.features.explore.presentation.components.recyclerview
+
+import android.graphics.drawable.GradientDrawable
+import android.content.res.ColorStateList
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageButton
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.example.twdist_android.R
+import com.example.twdist_android.features.explore.presentation.model.ProjectUi
+
+class ProjectListRecyclerAdapter :
+    ListAdapter<ProjectUi, ProjectRowViewHolder>(Diff) {
+
+    var onProjectClick: (ProjectUi) -> Unit = {}
+    var onStarClick: (ProjectUi) -> Unit = {}
+    var rowColors: ProjectRowColors = ProjectRowColors.defaultLightFallback()
+
+    fun syncListAndColors(projects: List<ProjectUi>, colors: ProjectRowColors) {
+        val colorChanged = rowColors != colors
+        rowColors = colors
+        submitList(projects) {
+            if (colorChanged) {
+                notifyItemRangeChanged(0, itemCount)
+            }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ProjectRowViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_project_list_row, parent, false)
+        return ProjectRowViewHolder(view, onProjectClick, onStarClick)
+    }
+
+    override fun onBindViewHolder(holder: ProjectRowViewHolder, position: Int) {
+        holder.bind(getItem(position), onProjectClick, onStarClick, rowColors)
+    }
+
+    private object Diff : DiffUtil.ItemCallback<ProjectUi>() {
+        override fun areItemsTheSame(oldItem: ProjectUi, newItem: ProjectUi): Boolean =
+            oldItem.id == newItem.id
+
+        override fun areContentsTheSame(oldItem: ProjectUi, newItem: ProjectUi): Boolean =
+            oldItem == newItem
+    }
+}
+
+class ProjectRowViewHolder(
+    private val itemRoot: View,
+    private var onProjectClick: (ProjectUi) -> Unit,
+    private var onStarClick: (ProjectUi) -> Unit
+) : RecyclerView.ViewHolder(itemRoot) {
+    private val nameView: TextView = itemRoot.findViewById(R.id.project_name)
+    private val pendingView: TextView = itemRoot.findViewById(R.id.pending_count)
+    private val starButton: ImageButton = itemRoot.findViewById(R.id.star_button)
+    private val navigateIcon: ImageView = itemRoot.findViewById(R.id.navigate_icon)
+
+    private var bound: ProjectUi? = null
+
+    /** Same as [com.example.twdist_android.features.explore.presentation.components.ProjectCard] `remember { mutableStateOf(false) }`. */
+    private var starVisualFilled: Boolean = false
+    private var starVisualProjectId: Long = Long.MIN_VALUE
+
+    init {
+        itemRoot.setOnClickListener {
+            bound?.let { onProjectClick(it) }
+        }
+        starButton.setOnClickListener {
+            bound?.let { project ->
+                starVisualFilled = !starVisualFilled
+                applyStarVisual(rowColorsSnapshot())
+                onStarClick(project)
+            }
+        }
+        navigateIcon.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
+    }
+
+    private var lastRowColors: ProjectRowColors = ProjectRowColors.defaultLightFallback()
+
+    private fun rowColorsSnapshot(): ProjectRowColors = lastRowColors
+
+    fun bind(
+        project: ProjectUi,
+        projectClick: (ProjectUi) -> Unit,
+        starClick: (ProjectUi) -> Unit,
+        rowColors: ProjectRowColors
+    ) {
+        onProjectClick = projectClick
+        onStarClick = starClick
+        lastRowColors = rowColors
+        if (starVisualProjectId != project.id) {
+            starVisualProjectId = project.id
+            starVisualFilled = false
+        }
+        bound = project
+
+        val density = itemRoot.resources.displayMetrics.density
+        val cornerPx = 12f * density
+        itemRoot.background = GradientDrawable().apply {
+            shape = GradientDrawable.RECTANGLE
+            cornerRadius = cornerPx
+            setColor(rowColors.surfaceVariant)
+        }
+        pendingView.background = GradientDrawable().apply {
+            shape = GradientDrawable.OVAL
+            setColor(rowColors.primary)
+        }
+
+        nameView.text = project.name
+        nameView.setTextColor(rowColors.onSurface)
+        pendingView.text = project.pendingTasks.toString()
+
+        navigateIcon.imageTintList = ColorStateList.valueOf(rowColors.onSurface)
+
+        applyStarVisual(rowColors)
+    }
+
+    private fun applyStarVisual(rowColors: ProjectRowColors) {
+        val ctx = itemRoot.context
+        val starGold = ContextCompat.getColor(ctx, R.color.star_gold)
+        if (starVisualFilled) {
+            starButton.setImageResource(R.drawable.ic_star_filled_24)
+            starButton.imageTintList = ColorStateList.valueOf(starGold)
+        } else {
+            starButton.setImageResource(R.drawable.ic_star_outline_24)
+            starButton.imageTintList = ColorStateList.valueOf(rowColors.onSurface)
+        }
+    }
+}

--- a/app/src/main/java/com/example/twdist_android/features/explore/presentation/components/recyclerview/ProjectListRecyclerAdapter.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/presentation/components/recyclerview/ProjectListRecyclerAdapter.kt
@@ -63,7 +63,7 @@ class ProjectRowViewHolder(
 
     private var bound: ProjectUi? = null
 
-    /** Same as [com.example.twdist_android.features.explore.presentation.components.ProjectCard] `remember { mutableStateOf(false) }`. */
+    /** Mirrors favorite in the UI; seeded from [ProjectUi.isFavorite], toggled locally on star tap. */
     private var starVisualFilled: Boolean = false
     private var starVisualProjectId: Long = Long.MIN_VALUE
 
@@ -94,9 +94,13 @@ class ProjectRowViewHolder(
         onProjectClick = projectClick
         onStarClick = starClick
         lastRowColors = rowColors
+
+        val previous = bound
         if (starVisualProjectId != project.id) {
             starVisualProjectId = project.id
-            starVisualFilled = false
+            starVisualFilled = project.isFavorite
+        } else if (previous?.id == project.id && previous.isFavorite != project.isFavorite) {
+            starVisualFilled = project.isFavorite
         }
         bound = project
 

--- a/app/src/main/java/com/example/twdist_android/features/explore/presentation/components/recyclerview/ProjectRowColors.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/presentation/components/recyclerview/ProjectRowColors.kt
@@ -1,0 +1,17 @@
+package com.example.twdist_android.features.explore.presentation.components.recyclerview
+
+import android.graphics.Color
+
+data class ProjectRowColors(
+    val surfaceVariant: Int,
+    val primary: Int,
+    val onSurface: Int
+) {
+    companion object {
+        fun defaultLightFallback(): ProjectRowColors = ProjectRowColors(
+            surfaceVariant = Color.parseColor("#E7E0EC"),
+            primary = Color.parseColor("#6650a4"),
+            onSurface = Color.parseColor("#1C1B1F")
+        )
+    }
+}

--- a/app/src/main/java/com/example/twdist_android/features/explore/presentation/components/recyclerview/ProjectSwipeDeleteCallback.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/presentation/components/recyclerview/ProjectSwipeDeleteCallback.kt
@@ -1,0 +1,121 @@
+package com.example.twdist_android.features.explore.presentation.components.recyclerview
+
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.RectF
+import android.util.TypedValue
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.ItemTouchHelper
+import androidx.recyclerview.widget.RecyclerView
+import com.example.twdist_android.R
+
+class ProjectSwipeDeleteCallback(
+    private val adapter: ProjectListRecyclerAdapter,
+    var deleteSwipeLabel: String,
+    private val onSwipeDeleteThreshold: (projectId: Long) -> Unit
+) : ItemTouchHelper.SimpleCallback(0, ItemTouchHelper.RIGHT) {
+
+    private val redPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+
+    private val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = 0xFFFFFFFF.toInt()
+        textAlign = Paint.Align.CENTER
+    }
+
+    override fun onMove(
+        recyclerView: RecyclerView,
+        viewHolder: RecyclerView.ViewHolder,
+        target: RecyclerView.ViewHolder
+    ): Boolean = false
+
+    override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
+        val position = viewHolder.bindingAdapterPosition
+        if (position == RecyclerView.NO_POSITION) return
+        val project = adapter.currentList.getOrNull(position) ?: return
+        adapter.notifyItemChanged(position)
+        onSwipeDeleteThreshold(project.id)
+    }
+
+    override fun getSwipeThreshold(viewHolder: RecyclerView.ViewHolder): Float = 0.4f
+
+    override fun getSwipeEscapeVelocity(defaultValue: Float): Float = defaultValue * 6f
+
+    override fun onChildDraw(
+        c: Canvas,
+        recyclerView: RecyclerView,
+        viewHolder: RecyclerView.ViewHolder,
+        dX: Float,
+        dY: Float,
+        actionState: Int,
+        isCurrentlyActive: Boolean
+    ) {
+        if (actionState == ItemTouchHelper.ACTION_STATE_SWIPE && dX > 0f) {
+            val dm = recyclerView.resources.displayMetrics
+            val density = dm.density
+
+            // Same corner radius as the project row card (12dp).
+            val cardCornerRadius = TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP,
+                12f,
+                dm
+            )
+            val horizontalPad = 8f * density
+
+            redPaint.color = ContextCompat.getColor(recyclerView.context, R.color.swipe_delete_background)
+
+            val itemView = viewHolder.itemView
+            val left = itemView.left.toFloat()
+            val top = itemView.top.toFloat()
+            val right = left + dX
+            val bottom = itemView.bottom.toFloat()
+
+            val redRect = RectF(left, top, right, bottom)
+            // Cap radius when the strip is narrow so drawRoundRect stays valid and matches the row feel.
+            val rowHeight = bottom - top
+            val cornerR = minOf(cardCornerRadius, dX / 2f, rowHeight / 2f)
+            c.drawRoundRect(redRect, cornerR, cornerR, redPaint)
+
+            val label = deleteSwipeLabel
+            val baseTextSize = TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_SP,
+                16f,
+                dm
+            )
+            val minTextSize = TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_SP,
+                10f,
+                dm
+            )
+
+            textPaint.textSize = baseTextSize
+            var textWidth = textPaint.measureText(label)
+            val maxTextWidth = (dX - 2 * horizontalPad).coerceAtLeast(0f)
+
+            while (textWidth > maxTextWidth && textPaint.textSize > minTextSize) {
+                textPaint.textSize -= 0.5f
+                textWidth = textPaint.measureText(label)
+            }
+
+            val textX = left + dX / 2f
+            val fontMetrics = textPaint.fontMetrics
+            val textY = top + rowHeight / 2f - (fontMetrics.ascent + fontMetrics.descent) / 2f
+
+            if (dX > horizontalPad && maxTextWidth > 0f) {
+                c.save()
+                if (textWidth > maxTextWidth) {
+                    val scaleX = (maxTextWidth / textWidth).coerceIn(0.45f, 1f)
+                    c.scale(scaleX, 1f, textX, textY)
+                }
+                c.drawText(label, textX, textY, textPaint)
+                c.restore()
+            }
+        }
+        super.onChildDraw(c, recyclerView, viewHolder, dX, dY, actionState, isCurrentlyActive)
+    }
+
+    override fun clearView(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder) {
+        super.clearView(recyclerView, viewHolder)
+        viewHolder.itemView.translationX = 0f
+        viewHolder.itemView.translationY = 0f
+    }
+}

--- a/app/src/main/java/com/example/twdist_android/features/explore/presentation/event/ExploreEvent.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/presentation/event/ExploreEvent.kt
@@ -5,4 +5,7 @@ sealed class ExploreEvent {
     data class CreateProject(val name: String) : ExploreEvent()
     data object LoadProjects : ExploreEvent()
     data object ClearValidationErrors : ExploreEvent()
+    data class ShowDeleteProjectConfirmation(val projectId: Long) : ExploreEvent()
+    data object DismissDeleteProjectConfirmation : ExploreEvent()
+    data object ConfirmDeleteProject : ExploreEvent()
 }

--- a/app/src/main/java/com/example/twdist_android/features/explore/presentation/model/ExploreUiState.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/presentation/model/ExploreUiState.kt
@@ -7,5 +7,6 @@ data class ExploreUiState(
     val projects: List<ProjectUi> = emptyList(),
     val isLoading: Boolean = false,
     val error: String? = null,
-    val projectNameError: String? = null
+    val projectNameError: String? = null,
+    val projectPendingDelete: ProjectUi? = null
 )

--- a/app/src/main/java/com/example/twdist_android/features/explore/presentation/screens/ExploreScreen.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/presentation/screens/ExploreScreen.kt
@@ -2,9 +2,9 @@ package com.example.twdist_android.features.explore.presentation.screens
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -14,7 +14,8 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.twdist_android.features.explore.presentation.components.CreateProjectDialog
-import com.example.twdist_android.features.explore.presentation.components.ProjectList
+import com.example.twdist_android.features.explore.presentation.components.DeleteProjectDialog
+import com.example.twdist_android.features.explore.presentation.components.ProjectListRecycler
 import com.example.twdist_android.features.explore.presentation.components.SectionHeader
 import com.example.twdist_android.features.explore.presentation.event.ExploreEvent
 import com.example.twdist_android.features.explore.presentation.viewmodel.ExploreViewModel
@@ -51,39 +52,41 @@ fun ExploreScreen(
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
-        LazyColumn(
+        Column(
             modifier = Modifier
                 .fillMaxSize()
                 .background(MaterialTheme.colorScheme.background)
                 .padding(16.dp)
         ) {
-            item {
-                SectionHeader(
-                    title = "My projects",
-                    isExpanded = state.isExpanded,
-                    onExpandClick = { viewModel.handleEvent(ExploreEvent.ToggleExpanded) },
-                    onAddClick = { showCreateDialog = true }
-                )
-            }
+            SectionHeader(
+                title = "My projects",
+                isExpanded = state.isExpanded,
+                onExpandClick = { viewModel.handleEvent(ExploreEvent.ToggleExpanded) },
+                onAddClick = { showCreateDialog = true }
+            )
 
             if (state.isExpanded) {
                 // If its loading and no projects, show loading indicator
                 if (state.isLoading && state.projects.isEmpty()) {
-                    item {
-                        CircularProgressIndicator(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(32.dp)
-                                .wrapContentWidth()
-                        )
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
                     }
-                }
-
-                item {
-                    ProjectList(
+                } else {
+                    ProjectListRecycler(
                         projects = state.projects,
                         onProjectClick = { project -> onNavigateToProjectDetails(project.id) },
-                        onStarClick = { _ -> /* TODO: Logic add favourite */ }
+                        onStarClick = { _ -> /* TODO: Logic add favourite */ },
+                        onSwipeDeleteThreshold = { projectId ->
+                            viewModel.handleEvent(ExploreEvent.ShowDeleteProjectConfirmation(projectId))
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f)
                     )
                 }
             }
@@ -109,6 +112,14 @@ fun ExploreScreen(
             },
             onConfirm = { name -> viewModel.handleEvent(ExploreEvent.CreateProject(name)) },
             error = state.projectNameError
+        )
+    }
+
+    state.projectPendingDelete?.let { project ->
+        DeleteProjectDialog(
+            project = project,
+            onDismiss = { viewModel.handleEvent(ExploreEvent.DismissDeleteProjectConfirmation) },
+            onConfirm = { viewModel.handleEvent(ExploreEvent.ConfirmDeleteProject) }
         )
     }
 }

--- a/app/src/main/java/com/example/twdist_android/features/explore/presentation/viewmodel/ExploreViewModel.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/presentation/viewmodel/ExploreViewModel.kt
@@ -68,11 +68,7 @@ class ExploreViewModel @Inject constructor(
         val projectId = pending.id
         viewModelScope.launch {
             _uiState.update {
-                it.copy(
-                    projectPendingDelete = null,
-                    isLoading = true,
-                    error = null
-                )
+                it.copy(projectPendingDelete = null, error = null)
             }
             deleteProjectUseCase(projectId)
                 .onSuccess {

--- a/app/src/main/java/com/example/twdist_android/features/explore/presentation/viewmodel/ExploreViewModel.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/presentation/viewmodel/ExploreViewModel.kt
@@ -3,6 +3,7 @@ package com.example.twdist_android.features.explore.presentation.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.twdist_android.features.explore.application.usecases.CreateProjectUseCase
+import com.example.twdist_android.features.explore.application.usecases.DeleteProjectUseCase
 import com.example.twdist_android.features.explore.application.usecases.GetProjectsUseCase
 import com.example.twdist_android.features.explore.presentation.event.ExploreEvent
 import com.example.twdist_android.features.explore.presentation.mapper.CreateProjectFormData
@@ -20,7 +21,8 @@ import javax.inject.Inject
 @HiltViewModel
 class ExploreViewModel @Inject constructor(
     private val getProjectsUseCase: GetProjectsUseCase,
-    private val createProjectUseCase: CreateProjectUseCase
+    private val createProjectUseCase: CreateProjectUseCase,
+    private val deleteProjectUseCase: DeleteProjectUseCase
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ExploreUiState())
@@ -36,6 +38,9 @@ class ExploreViewModel @Inject constructor(
             is ExploreEvent.CreateProject -> createProject(event.name)
             is ExploreEvent.LoadProjects -> loadProjects()
             is ExploreEvent.ClearValidationErrors -> clearValidationErrors()
+            is ExploreEvent.ShowDeleteProjectConfirmation -> showDeleteConfirmation(event.projectId)
+            is ExploreEvent.DismissDeleteProjectConfirmation -> dismissDeleteConfirmation()
+            is ExploreEvent.ConfirmDeleteProject -> confirmDeleteProject()
         }
     }
 
@@ -47,12 +52,51 @@ class ExploreViewModel @Inject constructor(
         _uiState.update { it.copy(projectNameError = null) }
     }
 
+    private fun showDeleteConfirmation(projectId: Long) {
+        _uiState.update { state ->
+            val project = state.projects.find { it.id == projectId }
+            state.copy(projectPendingDelete = project)
+        }
+    }
+
+    private fun dismissDeleteConfirmation() {
+        _uiState.update { it.copy(projectPendingDelete = null) }
+    }
+
+    private fun confirmDeleteProject() {
+        val pending = _uiState.value.projectPendingDelete ?: return
+        val projectId = pending.id
+        viewModelScope.launch {
+            _uiState.update {
+                it.copy(
+                    projectPendingDelete = null,
+                    isLoading = true,
+                    error = null
+                )
+            }
+            deleteProjectUseCase(projectId)
+                .onSuccess {
+                    loadProjects()
+                }
+                .onFailure { e ->
+                    _uiState.update {
+                        it.copy(error = e.message, isLoading = false)
+                    }
+                }
+        }
+    }
+
     private fun loadProjects() {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true) }
 
             getProjectsUseCase().onSuccess { list ->
-                _uiState.update { it.copy(projects = list.map { it.toUi() }, isLoading = false) }
+                _uiState.update {
+                    it.copy(
+                        projects = list.map { p -> p.toUi() },
+                        isLoading = false
+                    )
+                }
             }.onFailure { e ->
                 _uiState.update { it.copy(error = e.message, isLoading = false) }
             }

--- a/app/src/main/res/drawable/ic_chevron_right.xml
+++ b/app/src/main/res/drawable/ic_chevron_right.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M10,6L8.59,7.41 13.17,12l-4.58,4.59L10,18l6,-6z" />
+</vector>

--- a/app/src/main/res/drawable/ic_star_filled_24.xml
+++ b/app/src/main/res/drawable/ic_star_filled_24.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Matches Material Icons Filled Star (same as Compose Icons.Filled.Star) -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2L9.19,8.63L2,9.24l5.46,4.73L5.82,21L12,17.27z" />
+</vector>

--- a/app/src/main/res/drawable/ic_star_outline_24.xml
+++ b/app/src/main/res/drawable/ic_star_outline_24.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Matches Material Icons Outlined Star (same as Compose Icons.Outlined.Star) -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M22,9.24l-7.19,-0.62L12,2L9.19,8.63L2,9.24l5.46,4.73L5.82,21L12,17.27L18.18,21l-1.63,-7.03L22,9.24zM12,15.4l-3.76,2.27l1,-4.28l-3.32,-2.88l4.38,-0.38L12,6.1l1.71,4.03l4.38,0.38l-3.32,2.88l1,4.28L12,15.4z" />
+</vector>

--- a/app/src/main/res/layout/item_project_list_row.xml
+++ b/app/src/main/res/layout/item_project_list_row.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="8dp"
+    android:background="@android:color/transparent"
+    android:clipToOutline="true"
+    android:elevation="2dp"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingStart="16dp"
+    android:paddingTop="16dp"
+    android:paddingEnd="16dp"
+    android:paddingBottom="16dp">
+
+    <TextView
+        android:id="@+id/project_name"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:fontFamily="sans-serif-medium"
+        android:textSize="16sp"
+        tools:text="My project"
+        tools:textColor="#1C1B1F" />
+
+    <TextView
+        android:id="@+id/pending_count"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_marginEnd="8dp"
+        android:gravity="center"
+        android:textColor="@color/white"
+        android:textSize="14sp"
+        android:textStyle="bold"
+        tools:background="#6650a4"
+        tools:text="3" />
+
+    <ImageButton
+        android:id="@+id/star_button"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:background="?android:attr/selectableItemBackgroundBorderless"
+        android:contentDescription="Star project"
+        android:padding="8dp"
+        android:scaleType="centerInside"
+        tools:src="@drawable/ic_star_outline_24" />
+
+    <ImageView
+        android:id="@+id/navigate_icon"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:contentDescription="Open project"
+        android:importantForAccessibility="no"
+        android:src="@drawable/ic_chevron_right" />
+</LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,6 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="star_gold">#FFFFD700</color>
+    <color name="swipe_delete_background">#FFD32F2F</color>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,9 +16,11 @@ okhttp = "4.12.0"
 hilt = "2.54"
 hiltNavigationCompose = "1.2.0"
 robolectric = "4.16.1"
+recyclerview = "1.4.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-recyclerview = { group = "androidx.recyclerview", name = "recyclerview", version.ref = "recyclerview" }
 androidx-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
 androidx-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
This pull request adds support for deleting projects in the Explore feature, including backend integration, dependency injection, domain logic, and new UI components. It introduces a swipe-to-delete gesture in the project list using a RecyclerView, a confirmation dialog before deletion, and all necessary wiring through the repository and use case layers.

**Backend and Domain Logic:**
- Added `deleteProject` to `ProjectRepository` and implemented it in `ProjectRepositoryImpl`, including a new API endpoint in `ExploreApi` for deleting projects.
- Created `DeleteProjectUseCase` to encapsulate the delete logic and update the state store.
- Registered `DeleteProjectUseCase` in the DI module for injection.

**UI Components and Interaction:**
- Introduced a new `ProjectListRecycler` composable, using a RecyclerView with swipe-to-delete gesture, custom adapter, and visual feedback.
- Added a `DeleteProjectDialog` composable for user confirmation before deletion.
- Updated `ExploreUiState` and `ExploreEvent` to track and handle delete confirmation flow.

**Dependency and Resource Updates:**
- Added `androidx.recyclerview` dependency to support the new RecyclerView-based UI.
- Updated imports and minor refactoring to support new features.

**Visual Changes:**
| New Swipe-Delete|
| :---: |
|<img width="387" height="189" alt="image" src="https://github.com/user-attachments/assets/75a00097-049f-42d2-894f-b927e051e742" />|

These changes together enable a modern, interactive, and robust project deletion experience in the Explore section.