### PR TITLE
Feat/favourite star

### DIFF
--- a/app/src/main/java/com/example/twdist_android/features/explore/application/usecases/ChangeProjectFavoriteUseCase.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/application/usecases/ChangeProjectFavoriteUseCase.kt
@@ -1,0 +1,18 @@
+package com.example.twdist_android.features.explore.application.usecases
+
+import com.example.twdist_android.features.explore.domain.repository.ProjectRepository
+import com.example.twdist_android.features.explore.domain.store.ProjectStateStore
+import javax.inject.Inject
+
+class ChangeProjectFavoriteUseCase @Inject constructor(
+    private val repository: ProjectRepository,
+    private val projectStateStore: ProjectStateStore
+) {
+    suspend operator fun invoke(projectId: Long, isFavorite: Boolean): Result<Unit> {
+        return repository.changeFavorite(projectId, isFavorite)
+            .onSuccess {
+                val existing = projectStateStore.getById(projectId) ?: return@onSuccess
+                projectStateStore.upsert(existing.copy(isFavorite = isFavorite))
+            }
+    }
+}

--- a/app/src/main/java/com/example/twdist_android/features/explore/data/dto/ChangeFavoriteRequestDto.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/data/dto/ChangeFavoriteRequestDto.kt
@@ -1,0 +1,8 @@
+package com.example.twdist_android.features.explore.data.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ChangeFavoriteRequestDto(
+    val favorite: Boolean
+)

--- a/app/src/main/java/com/example/twdist_android/features/explore/data/remote/ExploreApi.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/data/remote/ExploreApi.kt
@@ -1,6 +1,7 @@
 package com.example.twdist_android.features.explore.data.remote
 
 import com.example.twdist_android.features.explore.data.dto.CreateProjectRequestDto
+import com.example.twdist_android.features.explore.data.dto.ChangeFavoriteRequestDto
 import com.example.twdist_android.features.explore.data.dto.ProjectResponseDto
 import com.example.twdist_android.features.explore.data.dto.ProjectSummaryDto
 import retrofit2.Response
@@ -9,6 +10,7 @@ import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
+import retrofit2.http.PUT
 
 interface ExploreApi {
     @GET("projects/get")
@@ -21,4 +23,10 @@ interface ExploreApi {
 
     @DELETE("projects/{projectId}/delete")
     suspend fun deleteProject(@Path("projectId") projectId: Long): Response<Unit>
+
+    @PUT("projects/{projectId}/favorite")
+    suspend fun changeFavorite(
+        @Path("projectId") projectId: Long,
+        @Body request: ChangeFavoriteRequestDto
+    ): Response<Unit>
 }

--- a/app/src/main/java/com/example/twdist_android/features/explore/data/repository/ProjectRepositoryImpl.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/data/repository/ProjectRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.example.twdist_android.features.explore.data.repository
 
 import com.example.twdist_android.core.coroutines.runSuspendCatching
+import com.example.twdist_android.features.explore.data.dto.ChangeFavoriteRequestDto
 import com.example.twdist_android.features.explore.data.dto.CreateProjectRequestDto
 import com.example.twdist_android.features.explore.data.mapper.toDomainResponse
 import com.example.twdist_android.features.explore.data.mapper.toDomainSummary
@@ -44,6 +45,20 @@ class ProjectRepositoryImpl @Inject constructor(
         return runSuspendCatching {
             withContext(Dispatchers.IO) {
                 val response = api.deleteProject(projectId)
+                if (!response.isSuccessful) {
+                    throw HttpException(response)
+                }
+            }
+        }
+    }
+
+    override suspend fun changeFavorite(projectId: Long, isFavorite: Boolean): Result<Unit> {
+        return runSuspendCatching {
+            withContext(Dispatchers.IO) {
+                val response = api.changeFavorite(
+                    projectId = projectId,
+                    request = ChangeFavoriteRequestDto(favorite = isFavorite)
+                )
                 if (!response.isSuccessful) {
                     throw HttpException(response)
                 }

--- a/app/src/main/java/com/example/twdist_android/features/explore/domain/repository/ProjectRepository.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/domain/repository/ProjectRepository.kt
@@ -8,4 +8,5 @@ interface ProjectRepository {
     suspend fun getAllProjects(): Result<List<ProjectSummary>>
     suspend fun createProject(projectName: ProjectName): Result<Project>
     suspend fun deleteProject(projectId: Long): Result<Unit>
+    suspend fun changeFavorite(projectId: Long, isFavorite: Boolean): Result<Unit>
 }

--- a/app/src/main/java/com/example/twdist_android/features/explore/presentation/components/recyclerview/ProjectListRecyclerAdapter.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/presentation/components/recyclerview/ProjectListRecyclerAdapter.kt
@@ -63,18 +63,12 @@ class ProjectRowViewHolder(
 
     private var bound: ProjectUi? = null
 
-    /** Mirrors favorite in the UI; seeded from [ProjectUi.isFavorite], toggled locally on star tap. */
-    private var starVisualFilled: Boolean = false
-    private var starVisualProjectId: Long = Long.MIN_VALUE
-
     init {
         itemRoot.setOnClickListener {
             bound?.let { onProjectClick(it) }
         }
         starButton.setOnClickListener {
             bound?.let { project ->
-                starVisualFilled = !starVisualFilled
-                applyStarVisual(rowColorsSnapshot())
                 onStarClick(project)
             }
         }
@@ -82,8 +76,6 @@ class ProjectRowViewHolder(
     }
 
     private var lastRowColors: ProjectRowColors = ProjectRowColors.defaultLightFallback()
-
-    private fun rowColorsSnapshot(): ProjectRowColors = lastRowColors
 
     fun bind(
         project: ProjectUi,
@@ -94,14 +86,6 @@ class ProjectRowViewHolder(
         onProjectClick = projectClick
         onStarClick = starClick
         lastRowColors = rowColors
-
-        val previous = bound
-        if (starVisualProjectId != project.id) {
-            starVisualProjectId = project.id
-            starVisualFilled = project.isFavorite
-        } else if (previous?.id == project.id && previous.isFavorite != project.isFavorite) {
-            starVisualFilled = project.isFavorite
-        }
         bound = project
 
         val density = itemRoot.resources.displayMetrics.density
@@ -122,13 +106,13 @@ class ProjectRowViewHolder(
 
         navigateIcon.imageTintList = ColorStateList.valueOf(rowColors.onSurface)
 
-        applyStarVisual(rowColors)
+        applyStarVisual(project.isFavorite, rowColors)
     }
 
-    private fun applyStarVisual(rowColors: ProjectRowColors) {
+    private fun applyStarVisual(isFavorite: Boolean, rowColors: ProjectRowColors) {
         val ctx = itemRoot.context
         val starGold = ContextCompat.getColor(ctx, R.color.star_gold)
-        if (starVisualFilled) {
+        if (isFavorite) {
             starButton.setImageResource(R.drawable.ic_star_filled_24)
             starButton.imageTintList = ColorStateList.valueOf(starGold)
         } else {

--- a/app/src/main/java/com/example/twdist_android/features/explore/presentation/event/ExploreEvent.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/presentation/event/ExploreEvent.kt
@@ -4,6 +4,7 @@ sealed class ExploreEvent {
     data object ToggleExpanded : ExploreEvent()
     data class CreateProject(val name: String) : ExploreEvent()
     data object LoadProjects : ExploreEvent()
+    data class ToggleProjectFavorite(val projectId: Long) : ExploreEvent()
     data object ClearValidationErrors : ExploreEvent()
     data class ShowDeleteProjectConfirmation(val projectId: Long) : ExploreEvent()
     data object DismissDeleteProjectConfirmation : ExploreEvent()

--- a/app/src/main/java/com/example/twdist_android/features/explore/presentation/screens/ExploreScreen.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/presentation/screens/ExploreScreen.kt
@@ -80,7 +80,11 @@ fun ExploreScreen(
                     ProjectListRecycler(
                         projects = state.projects,
                         onProjectClick = { project -> onNavigateToProjectDetails(project.id) },
-                        onStarClick = { _ -> /* TODO: Logic add favourite */ },
+                        onStarClick = { project ->
+                            viewModel.handleEvent(
+                                ExploreEvent.ToggleProjectFavorite(projectId = project.id)
+                            )
+                        },
                         onSwipeDeleteThreshold = { projectId ->
                             viewModel.handleEvent(ExploreEvent.ShowDeleteProjectConfirmation(projectId))
                         },

--- a/app/src/main/java/com/example/twdist_android/features/explore/presentation/viewmodel/ExploreViewModel.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/presentation/viewmodel/ExploreViewModel.kt
@@ -2,6 +2,7 @@ package com.example.twdist_android.features.explore.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.twdist_android.features.explore.application.usecases.ChangeProjectFavoriteUseCase
 import com.example.twdist_android.features.explore.application.usecases.CreateProjectUseCase
 import com.example.twdist_android.features.explore.application.usecases.DeleteProjectUseCase
 import com.example.twdist_android.features.explore.application.usecases.GetProjectsUseCase
@@ -22,11 +23,13 @@ import javax.inject.Inject
 class ExploreViewModel @Inject constructor(
     private val getProjectsUseCase: GetProjectsUseCase,
     private val createProjectUseCase: CreateProjectUseCase,
-    private val deleteProjectUseCase: DeleteProjectUseCase
+    private val deleteProjectUseCase: DeleteProjectUseCase,
+    private val changeProjectFavoriteUseCase: ChangeProjectFavoriteUseCase
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ExploreUiState())
     val uiState: StateFlow<ExploreUiState> = _uiState
+    private val favoriteRequestVersion = mutableMapOf<Long, Int>()
 
     init {
         loadProjects()
@@ -37,6 +40,7 @@ class ExploreViewModel @Inject constructor(
             is ExploreEvent.ToggleExpanded -> toggleExpanded()
             is ExploreEvent.CreateProject -> createProject(event.name)
             is ExploreEvent.LoadProjects -> loadProjects()
+            is ExploreEvent.ToggleProjectFavorite -> toggleProjectFavorite(event.projectId)
             is ExploreEvent.ClearValidationErrors -> clearValidationErrors()
             is ExploreEvent.ShowDeleteProjectConfirmation -> showDeleteConfirmation(event.projectId)
             is ExploreEvent.DismissDeleteProjectConfirmation -> dismissDeleteConfirmation()
@@ -82,15 +86,58 @@ class ExploreViewModel @Inject constructor(
         }
     }
 
+    private fun toggleProjectFavorite(projectId: Long) {
+        val currentProject = _uiState.value.projects.firstOrNull { it.id == projectId } ?: return
+        val nextFavorite = !currentProject.isFavorite
+        val version = (favoriteRequestVersion[projectId] ?: 0) + 1
+        favoriteRequestVersion[projectId] = version
+
+        _uiState.update { state ->
+            state.copy(
+                projects = state.projects.map { project ->
+                    if (project.id == projectId) project.copy(isFavorite = nextFavorite) else project
+                },
+                error = null
+            )
+        }
+
+        viewModelScope.launch {
+            changeProjectFavoriteUseCase(projectId, nextFavorite)
+                .onFailure { e ->
+                    if (favoriteRequestVersion[projectId] == version) {
+                        _uiState.update { state ->
+                            state.copy(
+                                projects = state.projects.map { project ->
+                                    if (project.id == projectId) {
+                                        project.copy(isFavorite = !nextFavorite)
+                                    } else {
+                                        project
+                                    }
+                                },
+                                error = e.message
+                            )
+                        }
+                    }
+                }
+                .onSuccess {
+                    if (favoriteRequestVersion[projectId] == version) {
+                        favoriteRequestVersion.remove(projectId)
+                    }
+                }
+            }
+    }
+
     private fun loadProjects() {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true) }
 
             getProjectsUseCase().onSuccess { list ->
+                favoriteRequestVersion.clear()
                 _uiState.update {
                     it.copy(
                         projects = list.map { p -> p.toUi() },
-                        isLoading = false
+                        isLoading = false,
+                        error = null
                     )
                 }
             }.onFailure { e ->


### PR DESCRIPTION
This pull request implements the ability to favorite/unfavorite projects from the explore screen, including the UI, ViewModel, use case, repository, and API integration. The feature is built with optimistic UI updates and error handling to ensure a responsive user experience.

**Feature: Project Favorite/Unfavorite**

* Added a new use case `ChangeProjectFavoriteUseCase` to handle the business logic for favoriting/unfavoriting a project and updating the local state store accordingly.
* Extended the `ProjectRepository` interface and its implementation to support the `changeFavorite` method, which sends the favorite/unfavorite request to the backend using a new `ChangeFavoriteRequestDto` and the corresponding API endpoint.

**UI and State Management**

* Updated the `ExploreViewModel` to handle the new `ToggleProjectFavorite` event, perform optimistic UI updates for the favorite status, and revert changes if the backend request fails, including versioning to prevent race conditions.
* Modified the `ProjectListRecyclerAdapter` and its `ProjectRowViewHolder` to immediately reflect the favorite status in the UI based on the project state, removing the previous local visual toggle logic.
* Updated the `ExploreScreen` to dispatch the favorite toggle event when the star button is clicked.

**API Integration**

* Added a new `changeFavorite` endpoint to the `ExploreApi` interface using a PUT request and the appropriate DTO.

These changes together enable users to favorite or unfavorite projects from the explore screen, with a smooth and responsive experience that properly handles both success and failure cases.