### PR TITLE
Feat/task completed

### DIFF
--- a/app/src/main/java/com/example/twdist_android/di/ProjectDetailsModule.kt
+++ b/app/src/main/java/com/example/twdist_android/di/ProjectDetailsModule.kt
@@ -147,6 +147,12 @@ object ProjectDetailsModule {
 
     @Provides
     @Singleton
+    fun provideCompleteTaskUseCase(
+        repository: TaskRepository
+    ): CompleteTaskUseCase = CompleteTaskUseCase(repository)
+
+    @Provides
+    @Singleton
     fun provideDeleteTaskUseCase(
         repository: TaskRepository
     ): DeleteTaskUseCase = DeleteTaskUseCase(repository)

--- a/app/src/main/java/com/example/twdist_android/features/explore/application/usecases/ChangeProjectFavoriteUseCase.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/application/usecases/ChangeProjectFavoriteUseCase.kt
@@ -11,8 +11,10 @@ class ChangeProjectFavoriteUseCase @Inject constructor(
     suspend operator fun invoke(projectId: Long, isFavorite: Boolean): Result<Unit> {
         return repository.changeFavorite(projectId, isFavorite)
             .onSuccess {
-                val existing = projectStateStore.getById(projectId) ?: return@onSuccess
-                projectStateStore.upsert(existing.copy(isFavorite = isFavorite))
+                val existing = projectStateStore.getById(projectId)
+                if (existing != null) {
+                    projectStateStore.upsert(existing.copy(isFavorite = isFavorite))
+                }
             }
     }
 }

--- a/app/src/main/java/com/example/twdist_android/features/projectdetails/application/usecases/CompleteTaskUseCase.kt
+++ b/app/src/main/java/com/example/twdist_android/features/projectdetails/application/usecases/CompleteTaskUseCase.kt
@@ -1,0 +1,19 @@
+package com.example.twdist_android.features.projectdetails.application.usecases
+
+import com.example.twdist_android.features.projectdetails.domain.model.Task
+import com.example.twdist_android.features.projectdetails.domain.repository.TaskRepository
+import java.time.LocalDate
+import javax.inject.Inject
+
+class CompleteTaskUseCase @Inject constructor(
+    private val repository: TaskRepository
+) {
+    suspend operator fun invoke(
+        projectId: Long,
+        sectionId: Long,
+        taskId: Long,
+        completedDate: LocalDate?
+    ): Result<Task> {
+        return repository.completeTask(projectId, sectionId, taskId, completedDate)
+    }
+}

--- a/app/src/main/java/com/example/twdist_android/features/projectdetails/data/dto/CompleteTaskRequestDto.kt
+++ b/app/src/main/java/com/example/twdist_android/features/projectdetails/data/dto/CompleteTaskRequestDto.kt
@@ -1,0 +1,8 @@
+package com.example.twdist_android.features.projectdetails.data.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CompleteTaskRequestDto(
+    val completedDate: String? = null
+)

--- a/app/src/main/java/com/example/twdist_android/features/projectdetails/data/mapper/TaskCompletionMapper.kt
+++ b/app/src/main/java/com/example/twdist_android/features/projectdetails/data/mapper/TaskCompletionMapper.kt
@@ -1,0 +1,8 @@
+package com.example.twdist_android.features.projectdetails.data.mapper
+
+import com.example.twdist_android.features.projectdetails.data.dto.CompleteTaskRequestDto
+import java.time.LocalDate
+
+fun LocalDate?.toCompleteTaskRequestDto(): CompleteTaskRequestDto {
+    return CompleteTaskRequestDto(completedDate = this?.toString())
+}

--- a/app/src/main/java/com/example/twdist_android/features/projectdetails/data/mapper/TaskMapper.kt
+++ b/app/src/main/java/com/example/twdist_android/features/projectdetails/data/mapper/TaskMapper.kt
@@ -2,6 +2,10 @@ package com.example.twdist_android.features.projectdetails.data.mapper
 
 import com.example.twdist_android.features.projectdetails.data.dto.TaskResponseDto
 import com.example.twdist_android.features.projectdetails.domain.model.Task
+import java.time.Instant
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 
 fun TaskResponseDto.toDomainTask(sectionId: Long): Task {
     // Intentionally mapping only fields currently used by Project Details UI.
@@ -10,6 +14,20 @@ fun TaskResponseDto.toDomainTask(sectionId: Long): Task {
         id = id,
         sectionId = sectionId,
         name = name,
-        completed = completed
+        completed = isCompletedByDate()
     )
+}
+
+private fun TaskResponseDto.isCompletedByDate(now: Instant = Instant.now()): Boolean {
+    val parsedCompletedDate = completedDate
+        ?.let { parseCompletedDate(it) }
+        ?: return false
+    return !parsedCompletedDate.isAfter(now)
+}
+
+private fun parseCompletedDate(value: String): Instant? {
+    return runCatching { Instant.parse(value) }.getOrNull()
+        ?: runCatching { OffsetDateTime.parse(value).toInstant() }.getOrNull()
+        ?: runCatching { LocalDate.parse(value).atStartOfDay().toInstant(ZoneOffset.UTC) }.getOrNull()
+        ?: value.toLongOrNull()?.let { millis -> runCatching { Instant.ofEpochMilli(millis) }.getOrNull() }
 }

--- a/app/src/main/java/com/example/twdist_android/features/projectdetails/data/mapper/TaskMapper.kt
+++ b/app/src/main/java/com/example/twdist_android/features/projectdetails/data/mapper/TaskMapper.kt
@@ -7,14 +7,17 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 
-fun TaskResponseDto.toDomainTask(sectionId: Long): Task {
+fun TaskResponseDto.toDomainTask(
+    sectionId: Long,
+    now: Instant = Instant.now()
+): Task {
     // Intentionally mapping only fields currently used by Project Details UI.
     // Keep DTO fields (description/dates/subtasks) for forward compatibility with future task screens.
     return Task(
         id = id,
         sectionId = sectionId,
         name = name,
-        completed = isCompletedByDate()
+        completed = isCompletedByDate(now = now)
     )
 }
 

--- a/app/src/main/java/com/example/twdist_android/features/projectdetails/data/remote/ProjectDetailsApi.kt
+++ b/app/src/main/java/com/example/twdist_android/features/projectdetails/data/remote/ProjectDetailsApi.kt
@@ -2,6 +2,7 @@ package com.example.twdist_android.features.projectdetails.data.remote
 
 import com.example.twdist_android.features.projectdetails.data.dto.ProjectDetailResponseDto
 import com.example.twdist_android.features.projectdetails.data.dto.CreateTaskRequestDto
+import com.example.twdist_android.features.projectdetails.data.dto.CompleteTaskRequestDto
 import com.example.twdist_android.features.projectdetails.data.dto.SectionUpdateResponseDto
 import com.example.twdist_android.features.projectdetails.data.dto.TaskResponseDto
 import com.example.twdist_android.features.projectdetails.data.dto.UpdateProjectRequestDto
@@ -11,6 +12,7 @@ import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.PUT
@@ -70,6 +72,14 @@ interface ProjectDetailsApi {
         @Path("sectionId") sectionId: Long,
         @Path("taskId") taskId: Long,
         @Body request: UpdateTaskRequestDto
+    ): Response<TaskResponseDto>
+
+    @PATCH("projects/{projectId}/section/{sectionId}/task/{taskId}/complete")
+    suspend fun completeTask(
+        @Path("projectId") projectId: Long,
+        @Path("sectionId") sectionId: Long,
+        @Path("taskId") taskId: Long,
+        @Body request: CompleteTaskRequestDto
     ): Response<TaskResponseDto>
 
     @DELETE("projects/{projectId}/section/{sectionId}/task/{taskId}/delete")

--- a/app/src/main/java/com/example/twdist_android/features/projectdetails/data/repository/TaskRepositoryImpl.kt
+++ b/app/src/main/java/com/example/twdist_android/features/projectdetails/data/repository/TaskRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.example.twdist_android.features.projectdetails.data.repository
 
 import com.example.twdist_android.core.coroutines.runSuspendCatching
+import com.example.twdist_android.features.projectdetails.data.mapper.toCompleteTaskRequestDto
 import com.example.twdist_android.features.projectdetails.data.dto.CreateTaskRequestDto
 import com.example.twdist_android.features.projectdetails.data.dto.UpdateTaskRequestDto
 import com.example.twdist_android.features.projectdetails.data.mapper.toDomainTask
@@ -11,6 +12,7 @@ import com.example.twdist_android.features.projectdetails.domain.repository.Task
 import com.example.twdist_android.features.projectdetails.domain.store.TaskStateStore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.time.LocalDate
 import javax.inject.Inject
 
 class TaskRepositoryImpl @Inject constructor(
@@ -57,12 +59,35 @@ class TaskRepositoryImpl @Inject constructor(
                     projectId,
                     sectionId,
                     taskId,
-                    UpdateTaskRequestDto(name.asString())
+                    UpdateTaskRequestDto(name = name.asString())
                 )
                 if (!response.isSuccessful) {
                     error("Failed to update task (HTTP ${response.code()})")
                 }
                 val dto = response.body() ?: error("Task update returned empty body")
+                dto.toDomainTask(sectionId).also(taskStateStore::upsert)
+            }
+        }
+    }
+
+    override suspend fun completeTask(
+        projectId: Long,
+        sectionId: Long,
+        taskId: Long,
+        completedDate: LocalDate?
+    ): Result<Task> {
+        return runSuspendCatching {
+            withContext(Dispatchers.IO) {
+                val response = api.completeTask(
+                    projectId = projectId,
+                    sectionId = sectionId,
+                    taskId = taskId,
+                    request = completedDate.toCompleteTaskRequestDto()
+                )
+                if (!response.isSuccessful) {
+                    error("Failed to complete task (HTTP ${response.code()})")
+                }
+                val dto = response.body() ?: error("Task completion returned empty body")
                 dto.toDomainTask(sectionId).also(taskStateStore::upsert)
             }
         }

--- a/app/src/main/java/com/example/twdist_android/features/projectdetails/domain/repository/TaskRepository.kt
+++ b/app/src/main/java/com/example/twdist_android/features/projectdetails/domain/repository/TaskRepository.kt
@@ -2,10 +2,12 @@ package com.example.twdist_android.features.projectdetails.domain.repository
 
 import com.example.twdist_android.features.projectdetails.domain.model.Task
 import com.example.twdist_android.features.projectdetails.domain.model.TaskName
+import java.time.LocalDate
 
 interface TaskRepository {
     suspend fun getTasksBySection(projectId: Long, sectionId: Long): Result<List<Task>>
     suspend fun createTask(projectId: Long, sectionId: Long, name: TaskName): Result<Task>
     suspend fun updateTask(projectId: Long, sectionId: Long, taskId: Long, name: TaskName): Result<Task>
+    suspend fun completeTask(projectId: Long, sectionId: Long, taskId: Long, completedDate: LocalDate?): Result<Task>
     suspend fun deleteTask(projectId: Long, sectionId: Long, taskId: Long): Result<Unit>
 }

--- a/app/src/main/java/com/example/twdist_android/features/projectdetails/presentation/event/TaskEvent.kt
+++ b/app/src/main/java/com/example/twdist_android/features/projectdetails/presentation/event/TaskEvent.kt
@@ -15,4 +15,5 @@ sealed interface TaskEvent {
     data object DeleteTaskConfirmed : TaskEvent
     data object DeleteTaskDismissed : TaskEvent
     data class TaskCompletionToggled(val sectionId: Long, val taskId: Long) : TaskEvent
+    data class TaskCompletionUndoHandled(val undo: Boolean) : TaskEvent
 }

--- a/app/src/main/java/com/example/twdist_android/features/projectdetails/presentation/event/TaskEvent.kt
+++ b/app/src/main/java/com/example/twdist_android/features/projectdetails/presentation/event/TaskEvent.kt
@@ -16,4 +16,5 @@ sealed interface TaskEvent {
     data object DeleteTaskDismissed : TaskEvent
     data class TaskCompletionToggled(val sectionId: Long, val taskId: Long) : TaskEvent
     data class TaskCompletionUndoHandled(val undo: Boolean) : TaskEvent
+    data object TaskSnackbarShown : TaskEvent
 }

--- a/app/src/main/java/com/example/twdist_android/features/projectdetails/presentation/model/ProjectDetailsUiState.kt
+++ b/app/src/main/java/com/example/twdist_android/features/projectdetails/presentation/model/ProjectDetailsUiState.kt
@@ -30,6 +30,7 @@ data class ProjectDetailsUiState(
     val deleteConfirmTaskSectionId: Long? = null,
     val deleteConfirmTaskId: Long? = null,
     val openTaskMenuForId: Long? = null,
+    val taskCompletionUndo: TaskCompletionUndo? = null,
     val sectionItems: List<SectionUi> = emptyList(),
     val tasksById: Map<String, TaskUi> = emptyMap()
 )
@@ -51,4 +52,9 @@ data class TaskUi(
     val id: Long,
     val name: String,
     val completed: Boolean
+)
+
+data class TaskCompletionUndo(
+    val sectionId: Long,
+    val task: TaskUi
 )

--- a/app/src/main/java/com/example/twdist_android/features/projectdetails/presentation/model/ProjectDetailsUiState.kt
+++ b/app/src/main/java/com/example/twdist_android/features/projectdetails/presentation/model/ProjectDetailsUiState.kt
@@ -31,6 +31,7 @@ data class ProjectDetailsUiState(
     val deleteConfirmTaskId: Long? = null,
     val openTaskMenuForId: Long? = null,
     val taskCompletionUndo: TaskCompletionUndo? = null,
+    val taskSnackbarMessage: String? = null,
     val sectionItems: List<SectionUi> = emptyList(),
     val tasksById: Map<String, TaskUi> = emptyMap()
 )

--- a/app/src/main/java/com/example/twdist_android/features/projectdetails/presentation/screens/ProjectDetailsScreen.kt
+++ b/app/src/main/java/com/example/twdist_android/features/projectdetails/presentation/screens/ProjectDetailsScreen.kt
@@ -79,6 +79,12 @@ fun ProjectDetailsScreen(
         viewModel.onTaskEvent(TaskEvent.TaskCompletionUndoHandled(undo = result == SnackbarResult.ActionPerformed))
     }
 
+    LaunchedEffect(uiState.taskSnackbarMessage) {
+        val message = uiState.taskSnackbarMessage ?: return@LaunchedEffect
+        snackbarHostState.showSnackbar(message = message, duration = SnackbarDuration.Short)
+        viewModel.onTaskEvent(TaskEvent.TaskSnackbarShown)
+    }
+
     Box(modifier = Modifier.fillMaxSize()) {
         when {
             uiState.isLoading -> LoadingState()

--- a/app/src/main/java/com/example/twdist_android/features/projectdetails/presentation/screens/ProjectDetailsScreen.kt
+++ b/app/src/main/java/com/example/twdist_android/features/projectdetails/presentation/screens/ProjectDetailsScreen.kt
@@ -14,6 +14,10 @@ import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
@@ -24,6 +28,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -36,6 +41,8 @@ import com.example.twdist_android.features.projectdetails.presentation.event.Sec
 import com.example.twdist_android.features.projectdetails.presentation.event.TaskEvent
 import com.example.twdist_android.features.projectdetails.presentation.model.ProjectDetailsUiState
 import com.example.twdist_android.features.projectdetails.presentation.viewmodel.ProjectDetailsViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 @Composable
 fun ProjectDetailsScreen(
@@ -44,6 +51,7 @@ fun ProjectDetailsScreen(
     viewModel: ProjectDetailsViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(projectId) {
         viewModel.loadProjectDetails(projectId)
@@ -56,19 +64,41 @@ fun ProjectDetailsScreen(
         }
     }
 
-    when {
-        uiState.isLoading -> LoadingState()
-        uiState.error != null -> ErrorState(
-            message = uiState.error!!,
-            onRetry = viewModel::retry
+    LaunchedEffect(uiState.taskCompletionUndo) {
+        val pendingUndo = uiState.taskCompletionUndo ?: return@LaunchedEffect
+        val autoDismissJob = launch {
+            delay(3_000)
+            snackbarHostState.currentSnackbarData?.dismiss()
+        }
+        val result = snackbarHostState.showSnackbar(
+            message = "Task was marked as complete",
+            actionLabel = "Undo",
+            duration = SnackbarDuration.Indefinite
         )
-        uiState.project != null -> ProjectDetailsContent(
-            uiState = uiState,
-            onSectionEvent = viewModel::onSectionEvent,
-            onTaskEvent = viewModel::onTaskEvent,
-            onProjectEvent = viewModel::onProjectEvent
+        autoDismissJob.cancel()
+        viewModel.onTaskEvent(TaskEvent.TaskCompletionUndoHandled(undo = result == SnackbarResult.ActionPerformed))
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        when {
+            uiState.isLoading -> LoadingState()
+            uiState.error != null -> ErrorState(
+                message = uiState.error!!,
+                onRetry = viewModel::retry
+            )
+            uiState.project != null -> ProjectDetailsContent(
+                uiState = uiState,
+                onSectionEvent = viewModel::onSectionEvent,
+                onTaskEvent = viewModel::onTaskEvent,
+                onProjectEvent = viewModel::onProjectEvent
+            )
+            else -> MissingProjectDetails()
+        }
+
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter)
         )
-        else -> MissingProjectDetails()
     }
 }
 
@@ -110,6 +140,7 @@ private fun ErrorState(message: String, onRetry: () -> Unit) {
 
 @Composable
 private fun ProjectDetailsContent(
+    modifier: Modifier = Modifier,
     uiState: ProjectDetailsUiState,
     onSectionEvent: (SectionEvent) -> Unit,
     onTaskEvent: (TaskEvent) -> Unit,
@@ -117,7 +148,7 @@ private fun ProjectDetailsContent(
 ) {
     val project = uiState.project ?: return
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
             .padding(top = 16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)

--- a/app/src/main/java/com/example/twdist_android/features/projectdetails/presentation/viewmodel/ProjectDetailsViewModel.kt
+++ b/app/src/main/java/com/example/twdist_android/features/projectdetails/presentation/viewmodel/ProjectDetailsViewModel.kt
@@ -6,6 +6,7 @@ import com.example.twdist_android.features.projectdetails.application.usecases.D
 import com.example.twdist_android.features.projectdetails.application.usecases.DeleteSectionUseCase
 import com.example.twdist_android.features.projectdetails.application.usecases.DeleteTaskUseCase
 import com.example.twdist_android.features.projectdetails.application.usecases.CreateSectionUseCase
+import com.example.twdist_android.features.projectdetails.application.usecases.CompleteTaskUseCase
 import com.example.twdist_android.features.projectdetails.application.usecases.CreateTaskUseCase
 import com.example.twdist_android.features.projectdetails.application.usecases.GetProjectByIdUseCase
 import com.example.twdist_android.features.projectdetails.application.usecases.GetTasksBySectionUseCase
@@ -21,12 +22,14 @@ import com.example.twdist_android.features.projectdetails.presentation.event.Tas
 import com.example.twdist_android.features.projectdetails.presentation.mapper.toDetailsUi
 import com.example.twdist_android.features.projectdetails.presentation.model.SectionUi
 import com.example.twdist_android.features.projectdetails.presentation.model.ProjectDetailsUiState
+import com.example.twdist_android.features.projectdetails.presentation.model.TaskCompletionUndo
 import com.example.twdist_android.features.projectdetails.presentation.model.TaskUi
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.time.LocalDate
 import javax.inject.Inject
 
 @HiltViewModel
@@ -40,6 +43,7 @@ class ProjectDetailsViewModel @Inject constructor(
     private val getTasksBySectionUseCase: GetTasksBySectionUseCase,
     private val createTaskUseCase: CreateTaskUseCase,
     private val updateTaskUseCase: UpdateTaskUseCase,
+    private val completeTaskUseCase: CompleteTaskUseCase,
     private val deleteTaskUseCase: DeleteTaskUseCase
 ) : ViewModel() {
 
@@ -120,6 +124,7 @@ class ProjectDetailsViewModel @Inject constructor(
             TaskEvent.DeleteTaskConfirmed -> onDeleteTaskConfirmed()
             TaskEvent.DeleteTaskDismissed -> onDeleteTaskDismissed()
             is TaskEvent.TaskCompletionToggled -> onTaskCompletionToggled(event.sectionId, event.taskId)
+            is TaskEvent.TaskCompletionUndoHandled -> onTaskCompletionUndoHandled(event.undo)
         }
     }
 
@@ -458,11 +463,12 @@ class ProjectDetailsViewModel @Inject constructor(
                             val mapped = tasks.map {
                                 TaskUi(id = it.id, name = it.name, completed = it.completed)
                             }
+                            val visibleTasks = mapped.filterNot { it.completed }
                             val nextTasksById = state.tasksById.toMutableMap().apply {
-                                mapped.forEach { put(it.id.toString(), it) }
+                                visibleTasks.forEach { put(it.id.toString(), it) }
                             }
                             val nextSections = state.sectionItems.map {
-                                if (it.id == section.id) it.copy(taskIds = mapped.map { t -> t.id.toString() }) else it
+                                if (it.id == section.id) it.copy(taskIds = visibleTasks.map { t -> t.id.toString() }) else it
                             }
                             state.copy(tasksById = nextTasksById, sectionItems = nextSections)
                         }
@@ -601,7 +607,12 @@ class ProjectDetailsViewModel @Inject constructor(
             }
         _uiState.update { it.copy(isTaskEditLoading = true, taskActionError = null) }
         viewModelScope.launch {
-            updateTaskUseCase(currentProjectId, sectionId, taskId, newName)
+            updateTaskUseCase(
+                projectId = currentProjectId,
+                sectionId = sectionId,
+                taskId = taskId,
+                name = newName
+            )
                 .onSuccess { updatedTask ->
                     _uiState.update { current ->
                         val updatedProject = current.project?.let { project ->
@@ -689,19 +700,116 @@ class ProjectDetailsViewModel @Inject constructor(
     }
 
     private fun onTaskCompletionToggled(sectionId: Long, taskId: Long) {
-        // TODO: Persist task completion once backend endpoint supports completion updates.
-        // FIXME: Current backend task update endpoint only accepts `name`, not completion status.
+        val state = _uiState.value
+        val currentProjectId = state.project?.id ?: return
+        val taskKey = taskId.toString()
+        val task = state.tasksById[taskKey] ?: return
+
         _uiState.update { current ->
-            val updatedProject = current.project?.let { project ->
-                project
+            current.copy(
+                tasksById = current.tasksById.toMutableMap().apply { remove(taskKey) },
+                sectionItems = current.sectionItems.map { section ->
+                    if (section.id == sectionId) {
+                        section.copy(taskIds = section.taskIds.filterNot { it == taskKey })
+                    } else {
+                        section
+                    }
+                },
+                taskCompletionUndo = TaskCompletionUndo(sectionId = sectionId, task = task),
+                taskActionError = null
+            )
+        }
+
+        viewModelScope.launch {
+            completeTaskUseCase(
+                projectId = currentProjectId,
+                sectionId = sectionId,
+                taskId = taskId,
+                completedDate = LocalDate.now()
+            ).onSuccess { updatedTask ->
+                if (!updatedTask.completed) {
+                    _uiState.update { current ->
+                        val nextTasksById = current.tasksById.toMutableMap().apply {
+                            put(taskKey, TaskUi(id = updatedTask.id, name = updatedTask.name, completed = updatedTask.completed))
+                        }
+                        val nextSections = current.sectionItems.map { section ->
+                            if (section.id == sectionId && taskKey !in section.taskIds) {
+                                section.copy(taskIds = section.taskIds + taskKey)
+                            } else {
+                                section
+                            }
+                        }
+                        current.copy(tasksById = nextTasksById, sectionItems = nextSections)
+                    }
+                }
+            }.onFailure { error ->
+                _uiState.update { current ->
+                    val nextTasksById = current.tasksById.toMutableMap().apply {
+                        put(taskKey, task)
+                    }
+                    val nextSections = current.sectionItems.map { section ->
+                        if (section.id == sectionId && taskKey !in section.taskIds) {
+                            section.copy(taskIds = section.taskIds + taskKey)
+                        } else {
+                            section
+                        }
+                    }
+                    current.copy(
+                        tasksById = nextTasksById,
+                        sectionItems = nextSections,
+                        taskCompletionUndo = null,
+                        taskActionError = error.message ?: "Could not update task"
+                    )
+                }
             }
-            val nextTasksById = current.tasksById.toMutableMap()
-            val key = taskId.toString()
-            val task = nextTasksById[key]
-            if (task != null) {
-                nextTasksById[key] = task.copy(completed = !task.completed)
+        }
+    }
+
+    private fun onTaskCompletionUndoHandled(undo: Boolean) {
+        val pendingUndo = _uiState.value.taskCompletionUndo ?: return
+        _uiState.update { it.copy(taskCompletionUndo = null) }
+        if (!undo) return
+
+        val projectId = _uiState.value.project?.id ?: return
+        val task = pendingUndo.task
+        val taskKey = task.id.toString()
+        val sectionId = pendingUndo.sectionId
+
+        _uiState.update { current ->
+            val nextTasksById = current.tasksById.toMutableMap().apply {
+                put(taskKey, task.copy(completed = false))
             }
-            current.copy(project = updatedProject, tasksById = nextTasksById)
+            val nextSections = current.sectionItems.map { section ->
+                if (section.id == sectionId && taskKey !in section.taskIds) {
+                    section.copy(taskIds = section.taskIds + taskKey)
+                } else section
+            }
+            current.copy(tasksById = nextTasksById, sectionItems = nextSections, taskActionError = null)
+        }
+
+        viewModelScope.launch {
+            completeTaskUseCase(
+                projectId = projectId,
+                sectionId = sectionId,
+                taskId = task.id,
+                completedDate = null
+            ).onFailure { error ->
+                _uiState.update { current ->
+                    val nextTasksById = current.tasksById.toMutableMap().apply {
+                        remove(taskKey)
+                    }
+                    val nextSections = current.sectionItems.map { section ->
+                        if (section.id == sectionId) {
+                            section.copy(taskIds = section.taskIds.filterNot { it == taskKey })
+                        } else section
+                    }
+                    current.copy(
+                        tasksById = nextTasksById,
+                        sectionItems = nextSections,
+                        taskActionError = error.message ?: "Could not undo task completion"
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/twdist_android/features/projectdetails/presentation/viewmodel/ProjectDetailsViewModel.kt
+++ b/app/src/main/java/com/example/twdist_android/features/projectdetails/presentation/viewmodel/ProjectDetailsViewModel.kt
@@ -125,6 +125,7 @@ class ProjectDetailsViewModel @Inject constructor(
             TaskEvent.DeleteTaskDismissed -> onDeleteTaskDismissed()
             is TaskEvent.TaskCompletionToggled -> onTaskCompletionToggled(event.sectionId, event.taskId)
             is TaskEvent.TaskCompletionUndoHandled -> onTaskCompletionUndoHandled(event.undo)
+            TaskEvent.TaskSnackbarShown -> onTaskSnackbarShown()
         }
     }
 
@@ -716,7 +717,8 @@ class ProjectDetailsViewModel @Inject constructor(
                     }
                 },
                 taskCompletionUndo = TaskCompletionUndo(sectionId = sectionId, task = task),
-                taskActionError = null
+                taskActionError = null,
+                taskSnackbarMessage = null
             )
         }
 
@@ -758,7 +760,8 @@ class ProjectDetailsViewModel @Inject constructor(
                         tasksById = nextTasksById,
                         sectionItems = nextSections,
                         taskCompletionUndo = null,
-                        taskActionError = error.message ?: "Could not update task"
+                        taskActionError = error.message ?: "Could not update task",
+                        taskSnackbarMessage = "Could not update task"
                     )
                 }
             }
@@ -793,7 +796,26 @@ class ProjectDetailsViewModel @Inject constructor(
                 sectionId = sectionId,
                 taskId = task.id,
                 completedDate = null
-            ).onFailure { error ->
+            ).onSuccess { updatedTask ->
+                if (updatedTask.completed) {
+                    _uiState.update { current ->
+                        val nextTasksById = current.tasksById.toMutableMap().apply {
+                            remove(taskKey)
+                        }
+                        val nextSections = current.sectionItems.map { section ->
+                            if (section.id == sectionId) {
+                                section.copy(taskIds = section.taskIds.filterNot { it == taskKey })
+                            } else section
+                        }
+                        current.copy(
+                            tasksById = nextTasksById,
+                            sectionItems = nextSections,
+                            taskActionError = "Could not undo task completion",
+                            taskSnackbarMessage = "Could not undo task completion"
+                        )
+                    }
+                }
+            }.onFailure { error ->
                 _uiState.update { current ->
                     val nextTasksById = current.tasksById.toMutableMap().apply {
                         remove(taskKey)
@@ -806,11 +828,16 @@ class ProjectDetailsViewModel @Inject constructor(
                     current.copy(
                         tasksById = nextTasksById,
                         sectionItems = nextSections,
-                        taskActionError = error.message ?: "Could not undo task completion"
+                        taskActionError = error.message ?: "Could not undo task completion",
+                        taskSnackbarMessage = "Could not undo task completion"
                     )
                 }
             }
         }
+    }
+
+    private fun onTaskSnackbarShown() {
+        _uiState.update { it.copy(taskSnackbarMessage = null) }
     }
 }
 

--- a/app/src/test/java/com/example/twdist_android/features/projectdetails/data/mapper/TaskMapperTest.kt
+++ b/app/src/test/java/com/example/twdist_android/features/projectdetails/data/mapper/TaskMapperTest.kt
@@ -50,4 +50,22 @@ class TaskMapperTest {
 
         assertEquals(true, mapped.completed)
     }
+
+    @Test
+    fun `toDomainTask should map as not completed when completedDate is in the future`() {
+        val fixedNow = Instant.parse("2026-01-10T00:00:00Z")
+        val dto = TaskResponseDto(
+            id = 4L,
+            name = "Task D",
+            completedDate = LocalDate.of(2026, 1, 11).toString(),
+            completed = true
+        )
+
+        val mapped = dto.toDomainTask(
+            sectionId = 10L,
+            now = fixedNow
+        )
+
+        assertEquals(false, mapped.completed)
+    }
 }

--- a/app/src/test/java/com/example/twdist_android/features/projectdetails/data/mapper/TaskMapperTest.kt
+++ b/app/src/test/java/com/example/twdist_android/features/projectdetails/data/mapper/TaskMapperTest.kt
@@ -1,0 +1,53 @@
+package com.example.twdist_android.features.projectdetails.data.mapper
+
+import com.example.twdist_android.features.projectdetails.data.dto.TaskResponseDto
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.Instant
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+
+class TaskMapperTest {
+
+    @Test
+    fun `toDomainTask should map as not completed when completedDate is null`() {
+        val dto = TaskResponseDto(
+            id = 1L,
+            name = "Task A",
+            completedDate = null,
+            completed = true
+        )
+
+        val mapped = dto.toDomainTask(sectionId = 10L)
+
+        assertEquals(false, mapped.completed)
+    }
+
+    @Test
+    fun `toDomainTask should map as completed when completedDate is in the past`() {
+        val dto = TaskResponseDto(
+            id = 2L,
+            name = "Task B",
+            completedDate = Instant.now().minus(1, ChronoUnit.DAYS).toString(),
+            completed = false
+        )
+
+        val mapped = dto.toDomainTask(sectionId = 10L)
+
+        assertEquals(true, mapped.completed)
+    }
+
+    @Test
+    fun `toDomainTask should map as completed when completedDate is local date string`() {
+        val dto = TaskResponseDto(
+            id = 3L,
+            name = "Task C",
+            completedDate = LocalDate.now().minusDays(1).toString(),
+            completed = false
+        )
+
+        val mapped = dto.toDomainTask(sectionId = 10L)
+
+        assertEquals(true, mapped.completed)
+    }
+}

--- a/app/src/test/java/com/example/twdist_android/features/projectdetails/presentation/viewmodel/ProjectDetailsViewModelTest.kt
+++ b/app/src/test/java/com/example/twdist_android/features/projectdetails/presentation/viewmodel/ProjectDetailsViewModelTest.kt
@@ -334,6 +334,27 @@ class ProjectDetailsViewModelTest {
     }
 
     @Test
+    fun `undo completed task should remove task and set snackbar when undo request fails`() = runTest {
+        val aggregate = createAggregate()
+        coEvery { projectDetailsRepository.getProjectById(1L) } returns Result.success(aggregate)
+        coEvery { taskRepository.completeTask(1L, 10L, 100L, any()) } returnsMany listOf(
+            Result.success(Task(id = 100L, sectionId = 10L, name = "task-1", completed = true)),
+            Result.failure(IllegalStateException("backend error"))
+        )
+
+        viewModel.loadProjectDetails(1L)
+        advanceUntilIdle()
+        viewModel.onTaskEvent(TaskEvent.TaskCompletionToggled(sectionId = 10L, taskId = 100L))
+        advanceUntilIdle()
+        viewModel.onTaskEvent(TaskEvent.TaskCompletionUndoHandled(undo = true))
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertNull(state.tasksById["100"])
+        assertEquals("Could not undo task completion", state.taskSnackbarMessage)
+    }
+
+    @Test
     fun `loadProjectDetails should hide completed tasks from section list`() = runTest {
         val aggregate = createAggregate()
         coEvery { projectDetailsRepository.getProjectById(1L) } returns Result.success(aggregate)

--- a/app/src/test/java/com/example/twdist_android/features/projectdetails/presentation/viewmodel/ProjectDetailsViewModelTest.kt
+++ b/app/src/test/java/com/example/twdist_android/features/projectdetails/presentation/viewmodel/ProjectDetailsViewModelTest.kt
@@ -3,6 +3,7 @@ package com.example.twdist_android.features.projectdetails.presentation.viewmode
 import com.example.twdist_android.features.projectdetails.application.usecases.DeleteSectionUseCase
 import com.example.twdist_android.features.projectdetails.application.usecases.DeleteTaskUseCase
 import com.example.twdist_android.features.projectdetails.application.usecases.DeleteProjectUseCase
+import com.example.twdist_android.features.projectdetails.application.usecases.CompleteTaskUseCase
 import com.example.twdist_android.features.projectdetails.application.usecases.CreateSectionUseCase
 import com.example.twdist_android.features.projectdetails.application.usecases.CreateTaskUseCase
 import com.example.twdist_android.features.projectdetails.application.usecases.GetProjectByIdUseCase
@@ -66,6 +67,7 @@ class ProjectDetailsViewModelTest {
         val getTasksBySectionUseCase = GetTasksBySectionUseCase(taskRepository)
         val createTaskUseCase = CreateTaskUseCase(taskRepository)
         val updateTaskUseCase = UpdateTaskUseCase(taskRepository)
+        val completeTaskUseCase = CompleteTaskUseCase(taskRepository)
         val deleteTaskUseCase = DeleteTaskUseCase(taskRepository)
         coEvery { taskRepository.getTasksBySection(any(), any()) } returns Result.success(
             listOf(
@@ -87,6 +89,7 @@ class ProjectDetailsViewModelTest {
             getTasksBySectionUseCase = getTasksBySectionUseCase,
             createTaskUseCase = createTaskUseCase,
             updateTaskUseCase = updateTaskUseCase,
+            completeTaskUseCase = completeTaskUseCase,
             deleteTaskUseCase = deleteTaskUseCase
         )
     }
@@ -291,16 +294,63 @@ class ProjectDetailsViewModelTest {
     }
 
     @Test
-    fun `task completion toggle should update local state only`() = runTest {
+    fun `task completion toggle should remove task from visible state`() = runTest {
         val aggregate = createAggregate()
         coEvery { projectDetailsRepository.getProjectById(1L) } returns Result.success(aggregate)
+        coEvery { taskRepository.completeTask(1L, 10L, 100L, any()) } returns Result.success(
+            Task(id = 100L, sectionId = 10L, name = "task-1", completed = true)
+        )
 
         viewModel.loadProjectDetails(1L)
         advanceUntilIdle()
         viewModel.onTaskEvent(TaskEvent.TaskCompletionToggled(sectionId = 10L, taskId = 100L))
+        advanceUntilIdle()
 
-        val task = viewModel.uiState.value.tasksById["100"]
-        assertEquals(true, task?.completed)
+        val state = viewModel.uiState.value
+        assertNull(state.tasksById["100"])
+        assertEquals(emptyList<String>(), state.sectionItems.firstOrNull { it.id == 10L }?.taskIds)
+        coVerify(exactly = 1) { taskRepository.completeTask(1L, 10L, 100L, any()) }
+    }
+
+    @Test
+    fun `undo completed task should restore task in visible state`() = runTest {
+        val aggregate = createAggregate()
+        coEvery { projectDetailsRepository.getProjectById(1L) } returns Result.success(aggregate)
+        coEvery { taskRepository.completeTask(1L, 10L, 100L, any()) } returnsMany listOf(
+            Result.success(Task(id = 100L, sectionId = 10L, name = "task-1", completed = true)),
+            Result.success(Task(id = 100L, sectionId = 10L, name = "task-1", completed = false))
+        )
+
+        viewModel.loadProjectDetails(1L)
+        advanceUntilIdle()
+        viewModel.onTaskEvent(TaskEvent.TaskCompletionToggled(sectionId = 10L, taskId = 100L))
+        advanceUntilIdle()
+        viewModel.onTaskEvent(TaskEvent.TaskCompletionUndoHandled(undo = true))
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertEquals("task-1", state.tasksById["100"]?.name)
+        assertEquals(listOf("100"), state.sectionItems.firstOrNull { it.id == 10L }?.taskIds)
+    }
+
+    @Test
+    fun `loadProjectDetails should hide completed tasks from section list`() = runTest {
+        val aggregate = createAggregate()
+        coEvery { projectDetailsRepository.getProjectById(1L) } returns Result.success(aggregate)
+        coEvery { taskRepository.getTasksBySection(any(), any()) } returns Result.success(
+            listOf(
+                Task(id = 100L, sectionId = 10L, name = "task-completed", completed = true),
+                Task(id = 101L, sectionId = 10L, name = "task-open", completed = false)
+            )
+        )
+
+        viewModel.loadProjectDetails(1L)
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertNull(state.tasksById["100"])
+        assertEquals("task-open", state.tasksById["101"]?.name)
+        assertEquals(listOf("101"), state.sectionItems.firstOrNull { it.id == 10L }?.taskIds)
     }
 
     private fun createAggregate(): ProjectAggregate {


### PR DESCRIPTION
This pull request adds the ability to mark tasks as complete (with optional undo), including backend integration, UI feedback, and related domain/data layer changes. It introduces a new use case for completing tasks, updates the repository and API layers, and implements a snackbar-based undo mechanism in the UI.

**Task Completion Feature**

* Added `CompleteTaskUseCase` and provided it via dependency injection to encapsulate the logic for marking a task as complete. 
* Extended the `TaskRepository` interface and its implementation to support completing a task, including sending the completed date to the backend. 
* Introduced `CompleteTaskRequestDto` and related mapping logic to serialize the completed date for network requests. 
* Updated the API interface (`ProjectDetailsApi`) to add a `PATCH` endpoint for completing tasks on the backend. 

**Task Completion Status Handling**

* Improved the task mapping logic to determine completion status based on the completed date, supporting multiple date formats for robustness. 

**UI and Undo Functionality**

* Added UI state and event handling for task completion undo, including a snackbar with an "Undo" action that triggers within three seconds after marking a task as complete.
* Updated the `ProjectDetailsScreen` and `ProjectDetailsViewModel` to wire up the new use case, state, and events for completion and undo.

These changes together provide a complete flow for marking a task as complete, reflecting the status in the UI, and allowing the user to undo the action shortly after.