### PR TITLE
Feat/today

### DIFF
--- a/app/src/main/java/com/example/twdist_android/core/ui/navigation/NavigationRoot.kt
+++ b/app/src/main/java/com/example/twdist_android/core/ui/navigation/NavigationRoot.kt
@@ -16,7 +16,7 @@ import com.example.twdist_android.features.auth.presentation.screens.RegisterScr
 import com.example.twdist_android.features.explore.presentation.screens.ExploreScreen
 import com.example.twdist_android.features.favorite.presentation.screens.FavoriteProjectScreen
 import com.example.twdist_android.features.projectdetails.presentation.screens.ProjectDetailsScreen
-import com.example.twdist_android.features.today.presentation.screens.TodayScreenPreview
+import com.example.twdist_android.features.today.presentation.screens.TodayScreen
 import com.example.twdist_android.features.upcoming.presentation.screens.UpcomingScreenPreview
 import kotlinx.serialization.Serializable
 
@@ -53,7 +53,7 @@ fun NavigationRoot() {
         entryProvider = entryProvider {
             entry<TodayScreenKey> {
                 AppScaffold(onNavItemClick = { (backStack as MutableList<NavKey>).add(it) }) {
-                    TodayScreenPreview()
+                    TodayScreen()
                 }
             }
             entry<UpcomingScreenKey> {

--- a/app/src/main/java/com/example/twdist_android/di/NetworkModule.kt
+++ b/app/src/main/java/com/example/twdist_android/di/NetworkModule.kt
@@ -5,6 +5,7 @@ import com.example.twdist_android.core.network.CookieJarImpl
 import com.example.twdist_android.features.auth.data.remote.AuthApi
 import com.example.twdist_android.features.explore.data.remote.ExploreApi
 import com.example.twdist_android.features.projectdetails.data.remote.ProjectDetailsApi
+import com.example.twdist_android.features.today.data.remote.TodayApi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -70,4 +71,9 @@ object NetworkModule {
     @Singleton
     fun provideProjectDetailsApi(retrofit: Retrofit): ProjectDetailsApi =
         retrofit.create(ProjectDetailsApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideTodayApi(retrofit: Retrofit): TodayApi =
+        retrofit.create(TodayApi::class.java)
 }

--- a/app/src/main/java/com/example/twdist_android/di/TodayModule.kt
+++ b/app/src/main/java/com/example/twdist_android/di/TodayModule.kt
@@ -1,0 +1,42 @@
+package com.example.twdist_android.di
+
+import com.example.twdist_android.features.today.application.usecases.CompleteTodayTaskUseCase
+import com.example.twdist_android.features.today.application.usecases.GetTodayTasksUseCase
+import com.example.twdist_android.features.today.application.usecases.UndoCompleteTodayTaskUseCase
+import com.example.twdist_android.features.today.data.remote.TodayApi
+import com.example.twdist_android.features.today.data.repository.TodayRepositoryImpl
+import com.example.twdist_android.features.today.domain.repository.TodayRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object TodayModule {
+
+    @Provides
+    @Singleton
+    fun provideTodayRepository(
+        api: TodayApi
+    ): TodayRepository = TodayRepositoryImpl(api)
+
+    @Provides
+    @Singleton
+    fun provideGetTodayTasksUseCase(
+        repository: TodayRepository
+    ): GetTodayTasksUseCase = GetTodayTasksUseCase(repository)
+
+    @Provides
+    @Singleton
+    fun provideCompleteTodayTaskUseCase(
+        repository: TodayRepository
+    ): CompleteTodayTaskUseCase = CompleteTodayTaskUseCase(repository)
+
+    @Provides
+    @Singleton
+    fun provideUndoCompleteTodayTaskUseCase(
+        repository: TodayRepository
+    ): UndoCompleteTodayTaskUseCase = UndoCompleteTodayTaskUseCase(repository)
+}

--- a/app/src/main/java/com/example/twdist_android/features/today/application/usecases/CompleteTodayTaskUseCase.kt
+++ b/app/src/main/java/com/example/twdist_android/features/today/application/usecases/CompleteTodayTaskUseCase.kt
@@ -1,0 +1,11 @@
+package com.example.twdist_android.features.today.application.usecases
+
+import com.example.twdist_android.features.today.domain.repository.TodayRepository
+import javax.inject.Inject
+
+class CompleteTodayTaskUseCase @Inject constructor(
+    private val repository: TodayRepository
+) {
+    suspend operator fun invoke(projectId: Long, sectionId: Long, taskId: Long): Result<Unit> =
+        repository.completeTask(projectId, sectionId, taskId)
+}

--- a/app/src/main/java/com/example/twdist_android/features/today/application/usecases/GetTodayTasksUseCase.kt
+++ b/app/src/main/java/com/example/twdist_android/features/today/application/usecases/GetTodayTasksUseCase.kt
@@ -1,0 +1,11 @@
+package com.example.twdist_android.features.today.application.usecases
+
+import com.example.twdist_android.features.today.domain.model.TodayTask
+import com.example.twdist_android.features.today.domain.repository.TodayRepository
+import javax.inject.Inject
+
+class GetTodayTasksUseCase @Inject constructor(
+    private val repository: TodayRepository
+) {
+    suspend operator fun invoke(): Result<List<TodayTask>> = repository.getTodayTasks()
+}

--- a/app/src/main/java/com/example/twdist_android/features/today/application/usecases/UndoCompleteTodayTaskUseCase.kt
+++ b/app/src/main/java/com/example/twdist_android/features/today/application/usecases/UndoCompleteTodayTaskUseCase.kt
@@ -1,0 +1,11 @@
+package com.example.twdist_android.features.today.application.usecases
+
+import com.example.twdist_android.features.today.domain.repository.TodayRepository
+import javax.inject.Inject
+
+class UndoCompleteTodayTaskUseCase @Inject constructor(
+    private val repository: TodayRepository
+) {
+    suspend operator fun invoke(projectId: Long, sectionId: Long, taskId: Long): Result<Unit> =
+        repository.undoCompleteTask(projectId, sectionId, taskId)
+}

--- a/app/src/main/java/com/example/twdist_android/features/today/data/dto/TodayTaskResponseDto.kt
+++ b/app/src/main/java/com/example/twdist_android/features/today/data/dto/TodayTaskResponseDto.kt
@@ -1,0 +1,16 @@
+package com.example.twdist_android.features.today.data.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TodayTaskResponseDto(
+    val id: Long,
+    val name: String,
+    val description: String? = null,
+    val startDate: String? = null,
+    val endDate: String? = null,
+    val completedDate: String? = null,
+    val sectionId: Long,
+    val projectId: Long,
+    val projectName: String
+)

--- a/app/src/main/java/com/example/twdist_android/features/today/data/mapper/TodayTaskMapper.kt
+++ b/app/src/main/java/com/example/twdist_android/features/today/data/mapper/TodayTaskMapper.kt
@@ -1,0 +1,12 @@
+package com.example.twdist_android.features.today.data.mapper
+
+import com.example.twdist_android.features.today.data.dto.TodayTaskResponseDto
+import com.example.twdist_android.features.today.domain.model.TodayTask
+
+fun TodayTaskResponseDto.toDomainTodayTask(): TodayTask = TodayTask(
+    id = id,
+    sectionId = sectionId,
+    name = name,
+    projectId = projectId,
+    projectName = projectName
+)

--- a/app/src/main/java/com/example/twdist_android/features/today/data/remote/TodayApi.kt
+++ b/app/src/main/java/com/example/twdist_android/features/today/data/remote/TodayApi.kt
@@ -1,0 +1,22 @@
+package com.example.twdist_android.features.today.data.remote
+
+import com.example.twdist_android.features.projectdetails.data.dto.task.CompleteTaskRequestDto
+import com.example.twdist_android.features.today.data.dto.TodayTaskResponseDto
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Body
+import retrofit2.http.PATCH
+import retrofit2.http.Path
+
+interface TodayApi {
+    @GET("tasks/today")
+    suspend fun getTodayTasks(): Response<List<TodayTaskResponseDto>>
+
+    @PATCH("projects/{projectId}/section/{sectionId}/task/{taskId}/complete")
+    suspend fun completeTask(
+        @Path("projectId") projectId: Long,
+        @Path("sectionId") sectionId: Long,
+        @Path("taskId") taskId: Long,
+        @Body request: CompleteTaskRequestDto
+    ): Response<Unit>
+}

--- a/app/src/main/java/com/example/twdist_android/features/today/data/repository/TodayRepositoryImpl.kt
+++ b/app/src/main/java/com/example/twdist_android/features/today/data/repository/TodayRepositoryImpl.kt
@@ -1,0 +1,62 @@
+package com.example.twdist_android.features.today.data.repository
+
+import com.example.twdist_android.core.coroutines.runSuspendCatching
+import com.example.twdist_android.features.projectdetails.data.dto.task.CompleteTaskRequestDto
+import com.example.twdist_android.features.projectdetails.data.mapper.toCompleteTaskRequestDto
+import com.example.twdist_android.features.today.data.mapper.toDomainTodayTask
+import com.example.twdist_android.features.today.data.remote.TodayApi
+import com.example.twdist_android.features.today.domain.model.TodayTask
+import com.example.twdist_android.features.today.domain.repository.TodayRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.time.LocalDate
+import javax.inject.Inject
+
+class TodayRepositoryImpl @Inject constructor(
+    private val api: TodayApi
+) : TodayRepository {
+
+    override suspend fun getTodayTasks(): Result<List<TodayTask>> {
+        return runSuspendCatching {
+            withContext(Dispatchers.IO) {
+                val response = api.getTodayTasks()
+                if (!response.isSuccessful) {
+                    error("Failed to fetch today tasks (HTTP ${response.code()})")
+                }
+                response.body().orEmpty().map { it.toDomainTodayTask() }
+            }
+        }
+    }
+
+    override suspend fun completeTask(projectId: Long, sectionId: Long, taskId: Long): Result<Unit> {
+        return runSuspendCatching {
+            withContext(Dispatchers.IO) {
+                val response = api.completeTask(
+                    projectId = projectId,
+                    sectionId = sectionId,
+                    taskId = taskId,
+                    request = LocalDate.now().toCompleteTaskRequestDto()
+                )
+                if (!response.isSuccessful) {
+                    error("Failed to complete task (HTTP ${response.code()})")
+                }
+            }
+        }
+    }
+
+    override suspend fun undoCompleteTask(projectId: Long, sectionId: Long, taskId: Long): Result<Unit> {
+        return runSuspendCatching {
+            withContext(Dispatchers.IO) {
+                val response = api.completeTask(
+                    projectId = projectId,
+                    sectionId = sectionId,
+                    taskId = taskId,
+                    request = CompleteTaskRequestDto(completedDate = null)
+                )
+                if (!response.isSuccessful) {
+                    error("Failed to undo task completion (HTTP ${response.code()})")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/twdist_android/features/today/domain/model/TodayTask.kt
+++ b/app/src/main/java/com/example/twdist_android/features/today/domain/model/TodayTask.kt
@@ -1,0 +1,9 @@
+package com.example.twdist_android.features.today.domain.model
+
+data class TodayTask(
+    val id: Long,
+    val sectionId: Long,
+    val name: String,
+    val projectId: Long,
+    val projectName: String
+)

--- a/app/src/main/java/com/example/twdist_android/features/today/domain/repository/TodayRepository.kt
+++ b/app/src/main/java/com/example/twdist_android/features/today/domain/repository/TodayRepository.kt
@@ -1,0 +1,9 @@
+package com.example.twdist_android.features.today.domain.repository
+
+import com.example.twdist_android.features.today.domain.model.TodayTask
+
+interface TodayRepository {
+    suspend fun getTodayTasks(): Result<List<TodayTask>>
+    suspend fun completeTask(projectId: Long, sectionId: Long, taskId: Long): Result<Unit>
+    suspend fun undoCompleteTask(projectId: Long, sectionId: Long, taskId: Long): Result<Unit>
+}

--- a/app/src/main/java/com/example/twdist_android/features/today/presentation/components/Task.kt
+++ b/app/src/main/java/com/example/twdist_android/features/today/presentation/components/Task.kt
@@ -1,60 +1,70 @@
 package com.example.twdist_android.features.today.presentation.components
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Card
-import androidx.compose.material3.Checkbox
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.example.twdist_android.features.today.presentation.model.TaskState
 
 @Composable
-fun Task(
+fun TodayTaskRow(
     task: TaskState,
-    onCheckedChange: (Boolean) -> Unit
+    onCompleted: (TaskState) -> Unit,
+    modifier: Modifier = Modifier
 ) {
-    Card(border = BorderStroke(2.dp, Color.Black)) {
+    Card(
+        modifier = modifier,
+        border = BorderStroke(1.dp, Color.Black)
+    ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(16.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Checkbox(
-                checked = task.isCompleted,
-                onCheckedChange = onCheckedChange
+            RadioButton(
+                selected = task.isCompleted,
+                onClick = { onCompleted(task) }
             )
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(text = task.title, fontSize = 20.sp)
+            Column {
+                Text(
+                    text = task.title,
+                    style = MaterialTheme.typography.titleMedium
+                )
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = task.projectName,
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
         }
     }
 }
 
 @Preview(showBackground = true)
 @Composable
-fun TaskPreview() {
-    var checked by remember { mutableStateOf(false) }
-
-    Task(
+fun TodayTaskRowPreview() {
+    TodayTaskRow(
         task = TaskState(
-            title = "Observación de un ecosistema cercano",
-            isCompleted = checked,
-            id = 0
+            title = "Write API integration tests",
+            projectName = "Backend",
+            id = 0L,
+            projectId = 1L,
+            sectionId = 1L
         ),
-        onCheckedChange = { checked = it }
+        onCompleted = {}
     )
 }

--- a/app/src/main/java/com/example/twdist_android/features/today/presentation/components/TaskList.kt
+++ b/app/src/main/java/com/example/twdist_android/features/today/presentation/components/TaskList.kt
@@ -2,22 +2,19 @@ package com.example.twdist_android.features.today.presentation.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.example.twdist_android.core.ui.theme.TWDistAndroidTheme
-import com.example.twdist_android.features.favorite.presentation.components.FavoriteProjectCard
 import com.example.twdist_android.features.today.presentation.model.TaskState
 
 @Composable
-fun TaskList(
+fun TodayTaskList(
     tasks: List<TaskState>,
+    onTaskCompleted: (TaskState) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     LazyColumn(
@@ -26,7 +23,10 @@ fun TaskList(
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         items(tasks) { task ->
-            Task(task = task, onCheckedChange = {})
+            TodayTaskRow(
+                task = task,
+                onCompleted = onTaskCompleted
+            )
         }
     }
 }
@@ -36,21 +36,30 @@ fun TaskList(
 private fun TaskListPreview() {
     val sampleTasks = listOf(
         TaskState(
-            id = 1,
+            id = 1L,
+            projectId = 1L,
+            sectionId = 1L,
             title = "Tema 1 y 2",
-            isCompleted = false
+            projectName = "School"
         ),
         TaskState(
-            id = 2,
+            id = 2L,
+            projectId = 1L,
+            sectionId = 1L,
             title = "Tareas de navidad",
-            isCompleted = false
+            projectName = "Personal"
         ),
         TaskState(
-            id = 3,
+            id = 3L,
+            projectId = 1L,
+            sectionId = 1L,
             title = "Repaso",
-            isCompleted = false
+            projectName = "Work"
         ),
     )
 
-    TaskList(tasks = sampleTasks)
+    TodayTaskList(
+        tasks = sampleTasks,
+        onTaskCompleted = {}
+    )
 }

--- a/app/src/main/java/com/example/twdist_android/features/today/presentation/model/TaskState.kt
+++ b/app/src/main/java/com/example/twdist_android/features/today/presentation/model/TaskState.kt
@@ -1,7 +1,10 @@
 package com.example.twdist_android.features.today.presentation.model
 
 data class TaskState(
-    val id: Int,
+    val id: Long,
+    val projectId: Long,
+    val sectionId: Long,
     val title: String,
-    val isCompleted: Boolean
+    val projectName: String,
+    val isCompleted: Boolean = false
 )

--- a/app/src/main/java/com/example/twdist_android/features/today/presentation/model/TodayUiEvent.kt
+++ b/app/src/main/java/com/example/twdist_android/features/today/presentation/model/TodayUiEvent.kt
@@ -1,0 +1,5 @@
+package com.example.twdist_android.features.today.presentation.model
+
+sealed interface TodayUiEvent {
+    data class TaskCompleted(val task: TaskState) : TodayUiEvent
+}

--- a/app/src/main/java/com/example/twdist_android/features/today/presentation/model/TodayUiState.kt
+++ b/app/src/main/java/com/example/twdist_android/features/today/presentation/model/TodayUiState.kt
@@ -1,0 +1,12 @@
+package com.example.twdist_android.features.today.presentation.model
+
+data class TodayUiState(
+    val isLoading: Boolean = false,
+    val title: String = "Today",
+    val formattedDate: String = "",
+    val tasks: List<TaskState> = emptyList(),
+    val error: String? = null
+) {
+    val totalCount: Int
+        get() = tasks.size
+}

--- a/app/src/main/java/com/example/twdist_android/features/today/presentation/screens/TodayScreen.kt
+++ b/app/src/main/java/com/example/twdist_android/features/today/presentation/screens/TodayScreen.kt
@@ -89,6 +89,7 @@ fun TodayScreenContent(
             fontWeight = FontWeight.W500,
             modifier = Modifier.padding(horizontal = 16.dp)
         )
+        Spacer(modifier = Modifier.height(8.dp))
         Text(
             text = uiState.formattedDate,
             style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/java/com/example/twdist_android/features/today/presentation/screens/TodayScreen.kt
+++ b/app/src/main/java/com/example/twdist_android/features/today/presentation/screens/TodayScreen.kt
@@ -1,56 +1,160 @@
 package com.example.twdist_android.features.today.presentation.screens
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.twdist_android.features.today.presentation.components.TaskList
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.twdist_android.features.today.presentation.components.TodayTaskList
 import com.example.twdist_android.features.today.presentation.model.TaskState
+import com.example.twdist_android.features.today.presentation.model.TodayUiEvent
+import com.example.twdist_android.features.today.presentation.model.TodayUiState
+import com.example.twdist_android.features.today.presentation.viewmodel.TodayViewModel
 
 @Composable
-fun TodayScreen(modifier: Modifier = Modifier, tasks: List<TaskState>) {
+fun TodayScreen(
+    viewModel: TodayViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
 
+    LaunchedEffect(viewModel) {
+        viewModel.events.collect { event ->
+            when (event) {
+                is TodayUiEvent.TaskCompleted -> {
+                    val result = snackbarHostState.showSnackbar(
+                        message = "Task completed",
+                        actionLabel = "Undo",
+                        duration = SnackbarDuration.Short
+                    )
+                    if (result == SnackbarResult.ActionPerformed) {
+                        viewModel.undoTaskCompleted(event.task)
+                    }
+                }
+            }
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        TodayScreenContent(
+            uiState = uiState,
+            onTaskCompleted = viewModel::onTaskCompleted,
+            modifier = Modifier
+        )
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 8.dp)
+        )
+    }
+}
+
+@Composable
+fun TodayScreenContent(
+    uiState: TodayUiState,
+    onTaskCompleted: (TaskState) -> Unit,
+    modifier: Modifier = Modifier
+) {
     Column(
         modifier = modifier
             .fillMaxSize()
             .padding(top = 16.dp)
     ) {
         Text(
-            text = "Ingles",
+            text = uiState.title,
             fontSize = 30.sp,
             fontWeight = FontWeight.W500,
             modifier = Modifier.padding(horizontal = 16.dp)
         )
-        Spacer(modifier = Modifier.height(16.dp))
-
-        TaskList(
-            tasks = tasks,
+        Text(
+            text = uiState.formattedDate,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(horizontal = 16.dp)
         )
+        Spacer(modifier = Modifier.height(16.dp))
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "${uiState.totalCount} tasks",
+                style = MaterialTheme.typography.titleSmall
+            )
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+
+        if (uiState.isLoading) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+        } else {
+            TodayTaskList(
+                tasks = uiState.tasks,
+                onTaskCompleted = onTaskCompleted
+            )
+        }
+
+        uiState.error?.let { error ->
+            Text(
+                text = error,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(16.dp)
+            )
+        }
     }
 }
 
 @Preview(showBackground = true)
 @Composable
-fun TodayScreenPreview() {
-    val tasks = listOf(
-        TaskState(
-            id = 1,
-            title = "Estudiar tema 1",
-            isCompleted = true
-        ), TaskState(
-            id = 2,
-            title = "Ejercicio 2 y 3",
-            isCompleted = true
-        )
+fun TodayScreenContentPreview() {
+    TodayScreenContent(
+        uiState = TodayUiState(
+            formattedDate = "Monday, 22 Jan",
+            tasks = listOf(
+                TaskState(
+                    id = 1L,
+                    projectId = 1L,
+                    sectionId = 1L,
+                    title = "Estudiar tema 1",
+                    projectName = "Ingles"
+                ),
+                TaskState(
+                    id = 2L,
+                    projectId = 1L,
+                    sectionId = 1L,
+                    title = "Ejercicio 2 y 3",
+                    projectName = "Matematicas"
+                )
+            )
+        ),
+        onTaskCompleted = {}
     )
-    TodayScreen(tasks = tasks)
 }

--- a/app/src/main/java/com/example/twdist_android/features/today/presentation/viewmodel/TodayViewModel.kt
+++ b/app/src/main/java/com/example/twdist_android/features/today/presentation/viewmodel/TodayViewModel.kt
@@ -1,0 +1,118 @@
+package com.example.twdist_android.features.today.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.twdist_android.features.today.application.usecases.CompleteTodayTaskUseCase
+import com.example.twdist_android.features.today.application.usecases.GetTodayTasksUseCase
+import com.example.twdist_android.features.today.application.usecases.UndoCompleteTodayTaskUseCase
+import com.example.twdist_android.features.today.presentation.model.TaskState
+import com.example.twdist_android.features.today.presentation.model.TodayUiEvent
+import com.example.twdist_android.features.today.presentation.model.TodayUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import javax.inject.Inject
+
+@HiltViewModel
+class TodayViewModel @Inject constructor(
+    private val getTodayTasksUseCase: GetTodayTasksUseCase,
+    private val completeTodayTaskUseCase: CompleteTodayTaskUseCase,
+    private val undoCompleteTodayTaskUseCase: UndoCompleteTodayTaskUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(
+        TodayUiState(formattedDate = formatTodayDate(LocalDate.now()))
+    )
+    val uiState: StateFlow<TodayUiState> = _uiState
+    private val _events = MutableSharedFlow<TodayUiEvent>()
+    val events: SharedFlow<TodayUiEvent> = _events
+
+    init {
+        loadTodayTasks()
+    }
+
+    fun loadTodayTasks() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null) }
+
+            getTodayTasksUseCase()
+                .onSuccess { tasks ->
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            tasks = tasks.map { task ->
+                                TaskState(
+                                    id = task.id,
+                                    projectId = task.projectId,
+                                    sectionId = task.sectionId,
+                                    title = task.name,
+                                    projectName = task.projectName,
+                                    isCompleted = false
+                                )
+                            }
+                        )
+                    }
+                }
+                .onFailure { throwable ->
+                    _uiState.update {
+                        it.copy(isLoading = false, error = throwable.message)
+                    }
+                }
+        }
+    }
+
+    fun onTaskCompleted(task: TaskState) {
+        if (task.isCompleted) return
+
+        viewModelScope.launch {
+            completeTodayTaskUseCase(
+                projectId = task.projectId,
+                sectionId = task.sectionId,
+                taskId = task.id
+            ).onSuccess {
+                _uiState.update { state ->
+                    state.copy(tasks = state.tasks.filterNot { it.id == task.id })
+                }
+                _events.emit(TodayUiEvent.TaskCompleted(task))
+            }.onFailure { throwable ->
+                _uiState.update { state ->
+                    state.copy(error = throwable.message)
+                }
+            }
+        }
+    }
+
+    fun undoTaskCompleted(task: TaskState) {
+        viewModelScope.launch {
+            undoCompleteTodayTaskUseCase(
+                projectId = task.projectId,
+                sectionId = task.sectionId,
+                taskId = task.id
+            ).onSuccess {
+                _uiState.update { state ->
+                    if (state.tasks.any { it.id == task.id }) {
+                        state
+                    } else {
+                        state.copy(tasks = listOf(task.copy(isCompleted = false)) + state.tasks)
+                    }
+                }
+            }.onFailure { throwable ->
+                _uiState.update { state ->
+                    state.copy(error = throwable.message)
+                }
+            }
+        }
+    }
+
+    private fun formatTodayDate(today: LocalDate): String {
+        val formatter = DateTimeFormatter.ofPattern("EEEE, dd MMM", Locale.ENGLISH)
+        return today.format(formatter)
+    }
+}


### PR DESCRIPTION
This pull request introduces the complete data, domain, and presentation layer integration for the "Today" tasks feature. It adds API, repository, use cases, dependency injection, and UI components for displaying and managing today's tasks, including completing and undoing completion of tasks. The navigation is updated to use the new `TodayScreen`, and the codebase is refactored to support the new models and UI flows.

**Today Feature Implementation**

* Added the `TodayApi` interface and its DI provisioning in `NetworkModule` to enable network calls for fetching and updating today's tasks.
* Implemented the `TodayRepository` interface and its concrete implementation `TodayRepositoryImpl`, including methods for getting, completing, and undoing completion of tasks.
* Introduced use cases for getting today tasks, completing a task, and undoing a completed task, with DI setup in the new `TodayModule`. 

**UI and Presentation Layer Updates**

* Replaced the preview screen with the real `TodayScreen` in navigation, and updated UI components: refactored `Task` to `TodayTaskRow`, and `TaskList` to `TodayTaskList`, adapting the model and event handling for the new feature.
* Updated the UI model (`TaskState`, `TodayUiState`, `TodayUiEvent`) to match the new data structure and enable event-driven task completion.

**Data Mapping and Model Definitions**

* Added DTOs, mappers, and domain models for today tasks, ensuring data is correctly transformed between layers.