### PR TITLE
chore: update build configuration to use KSP and upgrade Hilt version

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,10 +4,9 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
-    id("org.jetbrains.kotlin.kapt")
+    alias(libs.plugins.ksp)
     alias(libs.plugins.dagger.hilt)
 }
 
@@ -61,10 +60,6 @@ tasks.withType<KotlinCompile>().configureEach {
     }
 }
 
-kapt {
-    correctErrorTypes = true
-}
-
 dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.recyclerview)
@@ -85,7 +80,7 @@ dependencies {
 
     // Hilt
     implementation(libs.hilt.android)
-    add("kapt", libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
     implementation(libs.hilt.navigation.compose)
 
     // SavedStateHandle support

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,4 +5,5 @@ plugins {
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.dagger.hilt) apply false
+    alias(libs.plugins.ksp) apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,3 @@ android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
-
-# Disable built-in Kotlin to maintain compatibility with kapt/Hilt in AGP 9.0
-android.builtInKotlin=false
-android.newDsl=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,8 @@ kotlinxSerializationJson = "1.7.3"
 mockk = "1.14.9"
 retrofit = "2.11.0"
 okhttp = "4.12.0"
-hilt = "2.54"
+hilt = "2.59.2"
+ksp = "2.3.7"
 hiltNavigationCompose = "1.2.0"
 robolectric = "4.16.1"
 recyclerview = "1.4.0"
@@ -59,3 +60,4 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 dagger-hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
This PR fixes a crash on app startup caused by Hilt's generated class (MyApplication_GeneratedInjector) not being present in the APK.

Root cause: KAPT fails to run Hilt's annotation processor with the Kotlin 2.1.0 + AGP 9.0 stack, so the generated injector class is never produced. The app crashes immediately at Application creation with NoClassDefFoundError.

Dependency Updates:


- KAPT → KSP: KSP is the recommended annotation processor for Kotlin 2.x. KAPT is in maintenance mode and has known incompatibilities with this stack.
- Hilt 2.54 → 2.59.2: Hilt 2.54 requires the legacy AGP DSL (android.newDsl=false) to function. KSP2 requires the new DSL (android.newDsl=true, the AGP 9.0 default). Upgrading Hilt resolves this conflict — 2.59.2 explicitly adds AGP 9.0 support.
- Removed gradle.properties flags: android.builtInKotlin=false and android.newDsl=false were originally added as workarounds for KAPT + AGP 9.0 incompatibility. With KSP + Hilt 2.59.2, both flags are unnecessary and removing them unblocks KSP2.
- Removed kotlin-android plugin: With android.builtInKotlin=true (AGP 9.0 default), AGP applies Kotlin compilation automatically. Keeping the plugin causes a duplicate extension registration error.
