### PR TITLE
Refactor/upcoming start date

### DIFF
--- a/app/src/main/java/com/example/twdist_android/core/events/TaskEndDateUpdatedEvent.kt
+++ b/app/src/main/java/com/example/twdist_android/core/events/TaskEndDateUpdatedEvent.kt
@@ -1,5 +1,0 @@
-package com.example.twdist_android.core.events
-
-import java.time.LocalDate
-
-data class TaskEndDateUpdatedEvent(val taskId: Long, val newEndDate: LocalDate?)

--- a/app/src/main/java/com/example/twdist_android/core/events/TaskEventBus.kt
+++ b/app/src/main/java/com/example/twdist_android/core/events/TaskEventBus.kt
@@ -8,10 +8,10 @@ import kotlinx.coroutines.flow.SharedFlow
 
 @Singleton
 class TaskEventBus @Inject constructor() {
-    private val _taskEndDateUpdated = MutableSharedFlow<TaskEndDateUpdatedEvent>()
-    val taskEndDateUpdated: SharedFlow<TaskEndDateUpdatedEvent> = _taskEndDateUpdated
+    private val _taskStartDateUpdated = MutableSharedFlow<TaskStartDateUpdatedEvent>()
+    val taskStartDateUpdated: SharedFlow<TaskStartDateUpdatedEvent> = _taskStartDateUpdated
 
-    suspend fun emitEndDateUpdated(taskId: Long, newEndDate: LocalDate?) {
-        _taskEndDateUpdated.emit(TaskEndDateUpdatedEvent(taskId, newEndDate))
+    suspend fun emitStartDateUpdated(taskId: Long, newStartDate: LocalDate?) {
+        _taskStartDateUpdated.emit(TaskStartDateUpdatedEvent(taskId, newStartDate))
     }
 }

--- a/app/src/main/java/com/example/twdist_android/core/events/TaskStartDateUpdatedEvent.kt
+++ b/app/src/main/java/com/example/twdist_android/core/events/TaskStartDateUpdatedEvent.kt
@@ -1,0 +1,5 @@
+package com.example.twdist_android.core.events
+
+import java.time.LocalDate
+
+data class TaskStartDateUpdatedEvent(val taskId: Long, val newStartDate: LocalDate?)

--- a/app/src/main/java/com/example/twdist_android/features/taskdetails/presentation/viewmodel/TaskDetailsViewModel.kt
+++ b/app/src/main/java/com/example/twdist_android/features/taskdetails/presentation/viewmodel/TaskDetailsViewModel.kt
@@ -175,9 +175,9 @@ class TaskDetailsViewModel @Inject constructor(
                         saveMessage = "Task details saved"
                     )
                 }
-                taskEventBus.emitEndDateUpdated(
+                taskEventBus.emitStartDateUpdated(
                     taskId = taskId,
-                    newEndDate = updatedTask.endDate?.let {
+                    newStartDate = updatedTask.startDate?.let {
                         runCatching { LocalDate.parse(it) }.getOrNull()
                     }
                 )

--- a/app/src/main/java/com/example/twdist_android/features/upcoming/data/dto/UpcomingTaskResponseDto.kt
+++ b/app/src/main/java/com/example/twdist_android/features/upcoming/data/dto/UpcomingTaskResponseDto.kt
@@ -7,8 +7,8 @@ data class UpcomingTaskResponseDto(
     val id: Long,
     val name: String,
     val description: String? = null,
-    val startDate: String? = null,
-    val endDate: String,
+    val startDate: String,
+    val endDate: String? = null,
     val sectionId: Long,
     val projectId: Long,
     val projectName: String

--- a/app/src/main/java/com/example/twdist_android/features/upcoming/data/mapper/UpcomingTaskMapper.kt
+++ b/app/src/main/java/com/example/twdist_android/features/upcoming/data/mapper/UpcomingTaskMapper.kt
@@ -10,5 +10,5 @@ fun UpcomingTaskResponseDto.toDomainUpcomingTask(): UpcomingTask = UpcomingTask(
     projectId = projectId,
     name = name,
     projectName = projectName,
-    endDate = LocalDate.parse(endDate)
+    startDate = LocalDate.parse(startDate)
 )

--- a/app/src/main/java/com/example/twdist_android/features/upcoming/domain/model/UpcomingTask.kt
+++ b/app/src/main/java/com/example/twdist_android/features/upcoming/domain/model/UpcomingTask.kt
@@ -8,5 +8,5 @@ data class UpcomingTask(
     val projectId: Long,
     val name: String,
     val projectName: String,
-    val endDate: LocalDate
+    val startDate: LocalDate
 )

--- a/app/src/main/java/com/example/twdist_android/features/upcoming/presentation/screens/UpcomingScreen.kt
+++ b/app/src/main/java/com/example/twdist_android/features/upcoming/presentation/screens/UpcomingScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -23,6 +24,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -47,6 +51,20 @@ fun UpcomingScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
     var calendarExpanded by remember { mutableStateOf(false) }
+
+    // Silently refresh the task list every time this screen resumes so that tasks
+    // whose startDate was changed from another screen appear in the correct position
+    // without needing an app restart.
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                viewModel.refreshTasks()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
 
     // Derive the date of the top-most visible item by walking back from firstVisibleItemIndex
     // to find the nearest Header or Task item.

--- a/app/src/main/java/com/example/twdist_android/features/upcoming/presentation/viewmodel/UpcomingViewModel.kt
+++ b/app/src/main/java/com/example/twdist_android/features/upcoming/presentation/viewmodel/UpcomingViewModel.kt
@@ -41,8 +41,8 @@ class UpcomingViewModel @Inject constructor(
     init {
         loadUpcomingTasks()
         viewModelScope.launch {
-            taskEventBus.taskEndDateUpdated.collect { event ->
-                applyEndDateUpdate(event.taskId, event.newEndDate)
+            taskEventBus.taskStartDateUpdated.collect { event ->
+                applyStartDateUpdate(event.taskId, event.newStartDate)
             }
         }
     }
@@ -65,6 +65,21 @@ class UpcomingViewModel @Inject constructor(
                 }
                 .onFailure { throwable ->
                     _uiState.update { it.copy(isLoading = false, error = throwable.message) }
+                }
+        }
+    }
+
+    // Silent background refresh — no loading spinner, errors are swallowed so stale
+    // data keeps showing rather than flashing an error on every screen resume.
+    fun refreshTasks() {
+        viewModelScope.launch {
+            val today = LocalDate.now()
+            val endOfMonth = today.with(TemporalAdjusters.lastDayOfMonth())
+            getUpcomingTasksUseCase(from = today, to = endOfMonth)
+                .onSuccess { tasks ->
+                    _uiState.update { state ->
+                        state.copy(items = buildListItems(today, endOfMonth, tasks))
+                    }
                 }
         }
     }
@@ -129,7 +144,7 @@ class UpcomingViewModel @Inject constructor(
         }
     }
 
-    private fun applyEndDateUpdate(taskId: Long, newEndDate: LocalDate?) {
+    private fun applyStartDateUpdate(taskId: Long, newStartDate: LocalDate?) {
         val today = LocalDate.now()
         val endOfMonth = today.with(TemporalAdjusters.lastDayOfMonth())
 
@@ -143,11 +158,11 @@ class UpcomingViewModel @Inject constructor(
                 it is UpcomingListItem.Task && it.state.id == taskId
             }
 
-            if (newEndDate == null || newEndDate.isBefore(today) || newEndDate.isAfter(endOfMonth)) {
+            if (newStartDate == null || newStartDate.isBefore(today) || newStartDate.isAfter(endOfMonth)) {
                 return@update state.copy(items = withoutTask)
             }
 
-            val movedTask = existingTask.copy(date = newEndDate)
+            val movedTask = existingTask.copy(date = newStartDate)
             state.copy(items = reinsertTask(withoutTask, movedTask))
         }
     }
@@ -157,7 +172,7 @@ class UpcomingViewModel @Inject constructor(
         to: LocalDate,
         tasks: List<UpcomingTask>
     ): List<UpcomingListItem> {
-        val byDate = tasks.groupBy { it.endDate }
+        val byDate = tasks.groupBy { it.startDate }
         val result = mutableListOf<UpcomingListItem>()
         var current = from
         while (!current.isAfter(to)) {


### PR DESCRIPTION
This PR switches the feature to use startDate instead of endDate.

Preview on how the screen looks:

| Upcoming View |
|----------|
| <img width="252" height="544" alt="image" src="https://github.com/user-attachments/assets/58a751cc-0037-4ade-ab65-f9dc03c26baa" /> |



AI Summary:
This pull request refactors the handling of task dates throughout the codebase, standardizing on `startDate` instead of `endDate` for upcoming tasks and related events. It also improves the user experience by ensuring the upcoming tasks list refreshes automatically when the screen resumes, reflecting any changes made elsewhere in the app.

**Refactoring to use startDate for upcoming tasks:**

* Changed the `UpcomingTaskResponseDto`, `UpcomingTask`, and associated mapping logic to use `startDate` instead of `endDate` as the primary date field. 
* Updated grouping and display logic in `UpcomingViewModel` to organize tasks by `startDate` rather than `endDate`. 
* Renamed and refactored event handling to use `TaskStartDateUpdatedEvent` instead of `TaskEndDateUpdatedEvent`, including event bus methods and ViewModel logic. 

**User experience improvements:**

* Added a lifecycle-aware silent refresh to the upcoming tasks screen, so the task list updates automatically when the screen resumes, ensuring task positions reflect recent changes.

These changes ensure consistency in how task dates are managed and displayed, and improve the reliability of the upcoming tasks screen for users.