### PR TITLE
Fix/today startdate sync

### DIFF
--- a/app/src/main/java/com/example/twdist_android/core/events/TaskEventBus.kt
+++ b/app/src/main/java/com/example/twdist_android/core/events/TaskEventBus.kt
@@ -14,4 +14,11 @@ class TaskEventBus @Inject constructor() {
     suspend fun emitEndDateUpdated(taskId: Long, newEndDate: LocalDate?) {
         _taskEndDateUpdated.emit(TaskEndDateUpdatedEvent(taskId, newEndDate))
     }
+
+    private val _taskStartDateUpdated = MutableSharedFlow<TaskStartDateUpdatedEvent>()
+    val taskStartDateUpdated: SharedFlow<TaskStartDateUpdatedEvent> = _taskStartDateUpdated
+
+    suspend fun emitStartDateUpdated(event: TaskStartDateUpdatedEvent) {
+        _taskStartDateUpdated.emit(event)
+    }
 }

--- a/app/src/main/java/com/example/twdist_android/core/events/TaskEventBus.kt
+++ b/app/src/main/java/com/example/twdist_android/core/events/TaskEventBus.kt
@@ -1,6 +1,5 @@
 package com.example.twdist_android.core.events
 
-import java.time.LocalDate
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -8,13 +7,6 @@ import kotlinx.coroutines.flow.SharedFlow
 
 @Singleton
 class TaskEventBus @Inject constructor() {
-    private val _taskStartDateUpdated = MutableSharedFlow<TaskStartDateUpdatedEvent>()
-    val taskStartDateUpdated: SharedFlow<TaskStartDateUpdatedEvent> = _taskStartDateUpdated
-
-    suspend fun emitStartDateUpdated(taskId: Long, newStartDate: LocalDate?) {
-        _taskStartDateUpdated.emit(TaskStartDateUpdatedEvent(taskId, newStartDate))
-    }
-
     private val _taskStartDateUpdated = MutableSharedFlow<TaskStartDateUpdatedEvent>()
     val taskStartDateUpdated: SharedFlow<TaskStartDateUpdatedEvent> = _taskStartDateUpdated
 

--- a/app/src/main/java/com/example/twdist_android/core/events/TaskStartDateUpdatedEvent.kt
+++ b/app/src/main/java/com/example/twdist_android/core/events/TaskStartDateUpdatedEvent.kt
@@ -1,0 +1,12 @@
+package com.example.twdist_android.core.events
+
+import java.time.LocalDate
+
+data class TaskStartDateUpdatedEvent(
+    val taskId: Long,
+    val projectId: Long,
+    val sectionId: Long,
+    val taskName: String,
+    val projectName: String,
+    val newStartDate: LocalDate?
+)

--- a/app/src/main/java/com/example/twdist_android/features/taskdetails/presentation/screens/TaskDetailsScreen.kt
+++ b/app/src/main/java/com/example/twdist_android/features/taskdetails/presentation/screens/TaskDetailsScreen.kt
@@ -201,13 +201,6 @@ private fun TaskDetailsContent(
             )
         }
 
-        Button(
-            onClick = {},
-            enabled = false
-        ) {
-            Text(text = "Add Subtask")
-        }
-
         if (editingTaskId != null) {
             AlertDialog(
                 onDismissRequest = { onEvent(TaskDetailsEvent.TaskEditDismissed) },

--- a/app/src/main/java/com/example/twdist_android/features/taskdetails/presentation/viewmodel/TaskDetailsViewModel.kt
+++ b/app/src/main/java/com/example/twdist_android/features/taskdetails/presentation/viewmodel/TaskDetailsViewModel.kt
@@ -3,6 +3,7 @@ package com.example.twdist_android.features.taskdetails.presentation.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.twdist_android.core.events.TaskEventBus
+import com.example.twdist_android.core.events.TaskStartDateUpdatedEvent
 import com.example.twdist_android.features.projectdetails.application.usecases.task.CompleteTaskUseCase
 import com.example.twdist_android.features.projectdetails.application.usecases.task.DeleteTaskUseCase
 import com.example.twdist_android.features.projectdetails.application.usecases.project.GetProjectByIdUseCase
@@ -180,6 +181,18 @@ class TaskDetailsViewModel @Inject constructor(
                     newEndDate = updatedTask.endDate?.let {
                         runCatching { LocalDate.parse(it) }.getOrNull()
                     }
+                )
+                taskEventBus.emitStartDateUpdated(
+                    TaskStartDateUpdatedEvent(
+                        taskId = taskId,
+                        projectId = projectId,
+                        sectionId = sectionId,
+                        taskName = updatedTask.name,
+                        projectName = state.projectName,
+                        newStartDate = updatedTask.startDate?.let {
+                            runCatching { LocalDate.parse(it) }.getOrNull()
+                        }
+                    )
                 )
                 _events.emit(TaskDetailsUiEvent.NavigateBackToProjectDetails)
             }.onFailure { error ->

--- a/app/src/main/java/com/example/twdist_android/features/taskdetails/presentation/viewmodel/TaskDetailsViewModel.kt
+++ b/app/src/main/java/com/example/twdist_android/features/taskdetails/presentation/viewmodel/TaskDetailsViewModel.kt
@@ -177,12 +177,6 @@ class TaskDetailsViewModel @Inject constructor(
                     )
                 }
                 taskEventBus.emitStartDateUpdated(
-                    taskId = taskId,
-                    newStartDate = updatedTask.startDate?.let {
-                        runCatching { LocalDate.parse(it) }.getOrNull()
-                    }
-                )
-                taskEventBus.emitStartDateUpdated(
                     TaskStartDateUpdatedEvent(
                         taskId = taskId,
                         projectId = projectId,

--- a/app/src/main/java/com/example/twdist_android/features/today/data/repository/TodayRepositoryImpl.kt
+++ b/app/src/main/java/com/example/twdist_android/features/today/data/repository/TodayRepositoryImpl.kt
@@ -9,8 +9,18 @@ import com.example.twdist_android.features.today.domain.model.TodayTask
 import com.example.twdist_android.features.today.domain.repository.TodayRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.time.Instant
 import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.time.ZoneId
 import javax.inject.Inject
+
+private fun parseAnyDate(raw: String?): LocalDate? {
+    if (raw.isNullOrBlank()) return null
+    return runCatching { LocalDate.parse(raw) }.getOrNull()
+        ?: runCatching { OffsetDateTime.parse(raw).toLocalDate() }.getOrNull()
+        ?: runCatching { Instant.parse(raw).atZone(ZoneId.systemDefault()).toLocalDate() }.getOrNull()
+}
 
 class TodayRepositoryImpl @Inject constructor(
     private val api: TodayApi
@@ -23,7 +33,13 @@ class TodayRepositoryImpl @Inject constructor(
                 if (!response.isSuccessful) {
                     error("Failed to fetch today tasks (HTTP ${response.code()})")
                 }
-                response.body().orEmpty().map { it.toDomainTodayTask() }
+                val today = LocalDate.now()
+                response.body().orEmpty()
+                    .filter { dto ->
+                        val taskStartDate = parseAnyDate(dto.startDate)
+                        taskStartDate == today
+                    }
+                    .map { it.toDomainTodayTask() }
             }
         }
     }

--- a/app/src/main/java/com/example/twdist_android/features/today/presentation/viewmodel/TodayViewModel.kt
+++ b/app/src/main/java/com/example/twdist_android/features/today/presentation/viewmodel/TodayViewModel.kt
@@ -2,6 +2,8 @@ package com.example.twdist_android.features.today.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.twdist_android.core.events.TaskEventBus
+import com.example.twdist_android.core.events.TaskStartDateUpdatedEvent
 import com.example.twdist_android.core.ui.components.task.TaskRowState
 import com.example.twdist_android.features.today.application.usecases.CompleteTodayTaskUseCase
 import com.example.twdist_android.features.today.application.usecases.GetTodayTasksUseCase
@@ -24,7 +26,8 @@ import javax.inject.Inject
 class TodayViewModel @Inject constructor(
     private val getTodayTasksUseCase: GetTodayTasksUseCase,
     private val completeTodayTaskUseCase: CompleteTodayTaskUseCase,
-    private val undoCompleteTodayTaskUseCase: UndoCompleteTodayTaskUseCase
+    private val undoCompleteTodayTaskUseCase: UndoCompleteTodayTaskUseCase,
+    private val taskEventBus: TaskEventBus
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(
@@ -36,6 +39,11 @@ class TodayViewModel @Inject constructor(
 
     init {
         loadTodayTasks()
+        viewModelScope.launch {
+            taskEventBus.taskStartDateUpdated.collect { event ->
+                applyStartDateUpdate(event)
+            }
+        }
     }
 
     fun loadTodayTasks() {
@@ -107,6 +115,30 @@ class TodayViewModel @Inject constructor(
                 _uiState.update { state ->
                     state.copy(error = throwable.message)
                 }
+            }
+        }
+    }
+
+    private fun applyStartDateUpdate(event: TaskStartDateUpdatedEvent) {
+        val today = LocalDate.now()
+        _uiState.update { state ->
+            val existingIndex = state.tasks.indexOfFirst { it.id == event.taskId }
+            if (event.newStartDate == today) {
+                val updatedRow = TaskRowState(
+                    id = event.taskId,
+                    projectId = event.projectId,
+                    sectionId = event.sectionId,
+                    title = event.taskName,
+                    projectName = event.projectName,
+                    isCompleted = false
+                )
+                if (existingIndex >= 0) {
+                    state.copy(tasks = state.tasks.toMutableList().also { it[existingIndex] = updatedRow })
+                } else {
+                    state.copy(tasks = listOf(updatedRow) + state.tasks)
+                }
+            } else {
+                state.copy(tasks = state.tasks.filterNot { it.id == event.taskId })
             }
         }
     }

--- a/app/src/main/java/com/example/twdist_android/features/upcoming/data/dto/UpcomingTaskResponseDto.kt
+++ b/app/src/main/java/com/example/twdist_android/features/upcoming/data/dto/UpcomingTaskResponseDto.kt
@@ -8,7 +8,7 @@ data class UpcomingTaskResponseDto(
     val name: String,
     val description: String? = null,
     val startDate: String? = null,
-    val endDate: String,
+    val endDate: String? = null,
     val sectionId: Long,
     val projectId: Long,
     val projectName: String

--- a/app/src/main/java/com/example/twdist_android/features/upcoming/data/mapper/UpcomingTaskMapper.kt
+++ b/app/src/main/java/com/example/twdist_android/features/upcoming/data/mapper/UpcomingTaskMapper.kt
@@ -14,6 +14,6 @@ fun UpcomingTaskResponseDto.toDomainUpcomingTaskOrNull(): UpcomingTask? {
         projectId = projectId,
         name = name,
         projectName = projectName,
-        endDate = parsedDate
+        startDate = parsedDate
     )
 }

--- a/app/src/main/java/com/example/twdist_android/features/upcoming/data/mapper/UpcomingTaskMapper.kt
+++ b/app/src/main/java/com/example/twdist_android/features/upcoming/data/mapper/UpcomingTaskMapper.kt
@@ -4,11 +4,16 @@ import com.example.twdist_android.features.upcoming.data.dto.UpcomingTaskRespons
 import com.example.twdist_android.features.upcoming.domain.model.UpcomingTask
 import java.time.LocalDate
 
-fun UpcomingTaskResponseDto.toDomainUpcomingTask(): UpcomingTask = UpcomingTask(
-    id = id,
-    sectionId = sectionId,
-    projectId = projectId,
-    name = name,
-    projectName = projectName,
-    endDate = LocalDate.parse(endDate)
-)
+fun UpcomingTaskResponseDto.toDomainUpcomingTaskOrNull(): UpcomingTask? {
+    val dateString = endDate ?: startDate ?: return null
+    val parsedDate = runCatching { LocalDate.parse(dateString) }.getOrNull() ?: return null
+
+    return UpcomingTask(
+        id = id,
+        sectionId = sectionId,
+        projectId = projectId,
+        name = name,
+        projectName = projectName,
+        endDate = parsedDate
+    )
+}

--- a/app/src/main/java/com/example/twdist_android/features/upcoming/data/repository/UpcomingRepositoryImpl.kt
+++ b/app/src/main/java/com/example/twdist_android/features/upcoming/data/repository/UpcomingRepositoryImpl.kt
@@ -3,7 +3,7 @@ package com.example.twdist_android.features.upcoming.data.repository
 import com.example.twdist_android.core.coroutines.runSuspendCatching
 import com.example.twdist_android.features.projectdetails.data.dto.task.CompleteTaskRequestDto
 import com.example.twdist_android.features.projectdetails.data.mapper.toCompleteTaskRequestDto
-import com.example.twdist_android.features.upcoming.data.mapper.toDomainUpcomingTask
+import com.example.twdist_android.features.upcoming.data.mapper.toDomainUpcomingTaskOrNull
 import com.example.twdist_android.features.upcoming.data.remote.UpcomingApi
 import com.example.twdist_android.features.upcoming.domain.model.UpcomingTask
 import com.example.twdist_android.features.upcoming.domain.repository.UpcomingRepository
@@ -26,7 +26,7 @@ class UpcomingRepositoryImpl @Inject constructor(
                 if (!response.isSuccessful) {
                     error("Failed to fetch upcoming tasks (HTTP ${response.code()})")
                 }
-                response.body().orEmpty().map { it.toDomainUpcomingTask() }
+                response.body().orEmpty().mapNotNull { it.toDomainUpcomingTaskOrNull() }
             }
         }
     }


### PR DESCRIPTION
AI Summary:
This pull request introduces support for tracking and reacting to task start date updates across the application, improves how "Today" and "Upcoming" tasks are filtered and displayed, and fixes several issues with date handling. The changes ensure that the UI stays in sync with backend updates to task start dates, and that date parsing is more robust.

**Task Start Date Update Event System:**

* Added a new `TaskStartDateUpdatedEvent` data class to encapsulate start date changes for tasks.
* Extended `TaskEventBus` to support emitting and observing start date update events, including a new `emitStartDateUpdated` method and flow.
* Updated `TaskDetailsViewModel` to emit a `TaskStartDateUpdatedEvent` whenever a task's start date is changed.

**"Today" Tasks Filtering and UI Synchronization:**

* Improved the filtering logic in `TodayRepositoryImpl` to only include tasks whose start date is today, using a new `parseAnyDate` helper for robust date parsing.
* Updated `TodayViewModel` to listen for `TaskStartDateUpdatedEvent` and add, update, or remove tasks in the UI accordingly, keeping the "Today" list in sync with start date changes.

**"Upcoming" Tasks Date Handling:**

* Made the `endDate` field in `UpcomingTaskResponseDto` nullable, and updated the mapping logic to handle cases where only `startDate` or `endDate` is present, returning `null` if neither is available.
* Updated `UpcomingRepositoryImpl` to use the new mapping logic and ignore tasks without a valid date, preventing potential crashes or incorrect data.

**Other:**

* Removed the disabled "Add Subtask" button from the task details screen for UI clarity.