### PR TITLE
Feat/add missing previews

### DIFF
--- a/app/src/main/java/com/example/twdist_android/features/explore/presentation/screens/ExploreScreen.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/presentation/screens/ExploreScreen.kt
@@ -1,9 +1,21 @@
 package com.example.twdist_android.features.explore.presentation.screens
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -13,11 +25,14 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.twdist_android.core.ui.theme.TWDistAndroidTheme
 import com.example.twdist_android.features.explore.presentation.components.CreateProjectDialog
 import com.example.twdist_android.features.explore.presentation.components.DeleteProjectDialog
 import com.example.twdist_android.features.explore.presentation.components.ProjectListRecycler
 import com.example.twdist_android.features.explore.presentation.components.SectionHeader
 import com.example.twdist_android.features.explore.presentation.event.ExploreEvent
+import com.example.twdist_android.features.explore.presentation.model.ExploreUiState
+import com.example.twdist_android.features.explore.presentation.model.ProjectUi
 import com.example.twdist_android.features.explore.presentation.viewmodel.ExploreViewModel
 
 @Composable
@@ -40,78 +55,31 @@ fun ExploreScreen(
         }
     }
 
-    // Dialog states
     var showCreateDialog by remember { mutableStateOf(false) }
 
-    // Close dialog when project creation succeeds (projects list changes and no errors)
     LaunchedEffect(state.projects.size, state.projectNameError, state.isLoading) {
         if (showCreateDialog && !state.isLoading && state.projectNameError == null && state.error == null) {
-            // If we were showing dialog, not loading, and no errors, assume success
             showCreateDialog = false
         }
     }
 
-    Box(modifier = Modifier.fillMaxSize()) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background)
-                .padding(16.dp)
-        ) {
-            SectionHeader(
-                title = "My projects",
-                isExpanded = state.isExpanded,
-                onExpandClick = { viewModel.handleEvent(ExploreEvent.ToggleExpanded) },
-                onAddClick = { showCreateDialog = true }
-            )
-
-            if (state.isExpanded) {
-                // If its loading and no projects, show loading indicator
-                if (state.isLoading && state.projects.isEmpty()) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .weight(1f),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        CircularProgressIndicator()
-                    }
-                } else {
-                    ProjectListRecycler(
-                        projects = state.projects,
-                        onProjectClick = { project -> onNavigateToProjectDetails(project.id) },
-                        onStarClick = { project ->
-                            viewModel.handleEvent(
-                                ExploreEvent.ToggleProjectFavorite(projectId = project.id)
-                            )
-                        },
-                        onSwipeDeleteThreshold = { projectId ->
-                            viewModel.handleEvent(ExploreEvent.ShowDeleteProjectConfirmation(projectId))
-                        },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .weight(1f)
-                    )
-                }
-            }
+    ExploreScreenContent(
+        state = state,
+        onNavigateToProjectDetails = onNavigateToProjectDetails,
+        onToggleExpanded = { viewModel.handleEvent(ExploreEvent.ToggleExpanded) },
+        onAddClick = { showCreateDialog = true },
+        onToggleFavorite = { projectId ->
+            viewModel.handleEvent(ExploreEvent.ToggleProjectFavorite(projectId))
+        },
+        onSwipeDelete = { projectId ->
+            viewModel.handleEvent(ExploreEvent.ShowDeleteProjectConfirmation(projectId))
         }
+    )
 
-        // Show error message if exists (for business logic errors, not validation)
-        state.error?.let { msg ->
-            Text(
-                text = msg,
-                color = MaterialTheme.colorScheme.error,
-                modifier = Modifier.padding(16.dp)
-            )
-        }
-    }
-
-    // Create Project Dialog
     if (showCreateDialog) {
         CreateProjectDialog(
             onDismiss = {
                 showCreateDialog = false
-                // Clear any validation errors when dismissing
                 viewModel.handleEvent(ExploreEvent.ClearValidationErrors)
             },
             onConfirm = { name -> viewModel.handleEvent(ExploreEvent.CreateProject(name)) },
@@ -128,8 +96,95 @@ fun ExploreScreen(
     }
 }
 
+@Composable
+fun ExploreScreenContent(
+    state: ExploreUiState,
+    onNavigateToProjectDetails: (Long) -> Unit,
+    onToggleExpanded: () -> Unit,
+    onAddClick: () -> Unit,
+    onToggleFavorite: (Long) -> Unit,
+    onSwipeDelete: (Long) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(modifier = modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background)
+                .padding(16.dp)
+        ) {
+            SectionHeader(
+                title = "My projects",
+                isExpanded = state.isExpanded,
+                onExpandClick = onToggleExpanded,
+                onAddClick = onAddClick
+            )
+
+            if (state.isExpanded) {
+                if (state.isLoading && state.projects.isEmpty()) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                } else {
+                    ProjectListRecycler(
+                        projects = state.projects,
+                        onProjectClick = { project -> onNavigateToProjectDetails(project.id) },
+                        onStarClick = { project -> onToggleFavorite(project.id) },
+                        onSwipeDeleteThreshold = onSwipeDelete,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f)
+                    )
+                }
+            }
+        }
+
+        state.error?.let { msg ->
+            Text(
+                text = msg,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(16.dp)
+            )
+        }
+    }
+}
+
+private fun sampleExploreProjects(): List<ProjectUi> = listOf(
+    ProjectUi(id = 1L, name = "University", isFavorite = true, pendingTasks = 3),
+    ProjectUi(id = 2L, name = "Personal", isFavorite = false, pendingTasks = 1)
+)
+
 @Preview(showBackground = true)
 @Composable
-fun ExploreScreenPreview() {
-    ExploreScreen()
+private fun ExploreScreenContentPreview() {
+    TWDistAndroidTheme {
+        ExploreScreenContent(
+            state = ExploreUiState(projects = sampleExploreProjects()),
+            onNavigateToProjectDetails = {},
+            onToggleExpanded = {},
+            onAddClick = {},
+            onToggleFavorite = {},
+            onSwipeDelete = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ExploreScreenLoadingPreview() {
+    TWDistAndroidTheme {
+        ExploreScreenContent(
+            state = ExploreUiState(isLoading = true),
+            onNavigateToProjectDetails = {},
+            onToggleExpanded = {},
+            onAddClick = {},
+            onToggleFavorite = {},
+            onSwipeDelete = {}
+        )
+    }
 }

--- a/app/src/main/java/com/example/twdist_android/features/favorite/presentation/components/FavoriteProjectScreenPreview.kt
+++ b/app/src/main/java/com/example/twdist_android/features/favorite/presentation/components/FavoriteProjectScreenPreview.kt
@@ -1,15 +1,73 @@
 package com.example.twdist_android.features.favorite.presentation.components
 
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.tooling.preview.Preview
+import com.example.twdist_android.core.ui.theme.TWDistAndroidTheme
+import com.example.twdist_android.features.explore.presentation.model.ProjectUi
 import com.example.twdist_android.features.favorite.presentation.model.FavoriteProjectsUiState
 
-@Preview(showBackground = true)
+private fun sampleFavoriteProjects(): List<ProjectUi> = listOf(
+    ProjectUi(id = 1L, name = "University", isFavorite = true, pendingTasks = 3),
+    ProjectUi(id = 2L, name = "Personal", isFavorite = true, pendingTasks = 0)
+)
+
+@Preview(showBackground = true, name = "With projects")
 @Composable
-internal fun FavoriteProjectScreenPreview() {
-    FavoriteContent(
-        uiState = FavoriteProjectsUiState(),
-        onProjectClick = {},
-        onUnfavoriteClick = {}
-    )
+internal fun FavoriteProjectScreenContentPreview() {
+    TWDistAndroidTheme {
+        FavoriteProjectScreenContent(
+            uiState = FavoriteProjectsUiState(projects = sampleFavoriteProjects()),
+            snackbarHostState = remember { SnackbarHostState() },
+            onProjectClick = {},
+            onRetry = {},
+            onUnfavoriteClick = {}
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Loading")
+@Composable
+internal fun FavoriteProjectScreenLoadingPreview() {
+    TWDistAndroidTheme {
+        FavoriteProjectScreenContent(
+            uiState = FavoriteProjectsUiState(isLoading = true),
+            snackbarHostState = remember { SnackbarHostState() },
+            onProjectClick = {},
+            onRetry = {},
+            onUnfavoriteClick = {}
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Error")
+@Composable
+internal fun FavoriteProjectScreenErrorPreview() {
+    TWDistAndroidTheme {
+        FavoriteProjectScreenContent(
+            uiState = FavoriteProjectsUiState(
+                isLoading = false,
+                error = "Could not load favorite projects"
+            ),
+            snackbarHostState = remember { SnackbarHostState() },
+            onProjectClick = {},
+            onRetry = {},
+            onUnfavoriteClick = {}
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Empty")
+@Composable
+internal fun FavoriteProjectScreenEmptyPreview() {
+    TWDistAndroidTheme {
+        FavoriteProjectScreenContent(
+            uiState = FavoriteProjectsUiState(),
+            snackbarHostState = remember { SnackbarHostState() },
+            onProjectClick = {},
+            onRetry = {},
+            onUnfavoriteClick = {}
+        )
+    }
 }

--- a/app/src/main/java/com/example/twdist_android/features/projectdetails/presentation/screens/ProjectDetailsScreen.kt
+++ b/app/src/main/java/com/example/twdist_android/features/projectdetails/presentation/screens/ProjectDetailsScreen.kt
@@ -31,7 +31,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.example.twdist_android.core.ui.theme.TWDistAndroidTheme
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.twdist_android.features.projectdetails.presentation.components.SectionsRow
@@ -39,7 +41,10 @@ import com.example.twdist_android.features.projectdetails.presentation.component
 import com.example.twdist_android.features.projectdetails.presentation.event.ProjectEvent
 import com.example.twdist_android.features.projectdetails.presentation.event.SectionEvent
 import com.example.twdist_android.features.projectdetails.presentation.event.TaskEvent
+import com.example.twdist_android.features.projectdetails.presentation.model.ProjectDetailsUi
 import com.example.twdist_android.features.projectdetails.presentation.model.ProjectDetailsUiState
+import com.example.twdist_android.features.projectdetails.presentation.model.SectionUi
+import com.example.twdist_android.features.projectdetails.presentation.model.TaskUi
 import com.example.twdist_android.features.projectdetails.presentation.viewmodel.ProjectDetailsViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -262,5 +267,59 @@ private fun MissingProjectDetails() {
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
+    }
+}
+
+private fun sampleProjectDetailsUiState(): ProjectDetailsUiState {
+    val task = TaskUi(id = 1L, name = "Read chapter 3", completed = false)
+    val section = SectionUi(id = 1L, name = "To do", taskIds = listOf("1"))
+    return ProjectDetailsUiState(
+        isLoading = false,
+        project = ProjectDetailsUi(
+            id = 1L,
+            name = "University",
+            isFavorite = true,
+            sections = listOf("1")
+        ),
+        sectionItems = listOf(section),
+        tasksById = mapOf("1" to task)
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ProjectDetailsContentPreview() {
+    TWDistAndroidTheme {
+        ProjectDetailsContent(
+            uiState = sampleProjectDetailsUiState(),
+            onSectionEvent = {},
+            onTaskEvent = {},
+            onProjectEvent = {},
+            onTaskClick = { _, _ -> }
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ProjectDetailsLoadingPreview() {
+    TWDistAndroidTheme {
+        LoadingState()
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ProjectDetailsErrorPreview() {
+    TWDistAndroidTheme {
+        ErrorState(message = "Could not load project", onRetry = {})
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ProjectDetailsMissingPreview() {
+    TWDistAndroidTheme {
+        MissingProjectDetails()
     }
 }

--- a/app/src/main/java/com/example/twdist_android/features/taskdetails/presentation/components/TaskDetailsScreenStates.kt
+++ b/app/src/main/java/com/example/twdist_android/features/taskdetails/presentation/components/TaskDetailsScreenStates.kt
@@ -13,7 +13,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.example.twdist_android.core.ui.theme.TWDistAndroidTheme
 
 @Composable
 internal fun LoadingState() {
@@ -44,5 +46,21 @@ internal fun ErrorState(message: String) {
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun TaskDetailsLoadingPreview() {
+    TWDistAndroidTheme {
+        LoadingState()
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun TaskDetailsErrorPreview() {
+    TWDistAndroidTheme {
+        ErrorState(message = "Task not found")
     }
 }

--- a/app/src/main/java/com/example/twdist_android/features/taskdetails/presentation/screens/TaskDetailsScreen.kt
+++ b/app/src/main/java/com/example/twdist_android/features/taskdetails/presentation/screens/TaskDetailsScreen.kt
@@ -27,14 +27,16 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.example.twdist_android.core.ui.theme.TWDistAndroidTheme
+import com.example.twdist_android.features.taskdetails.presentation.event.TaskDetailsEvent
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.twdist_android.features.taskdetails.presentation.components.DateInputField
 import com.example.twdist_android.features.taskdetails.presentation.components.ErrorState
 import com.example.twdist_android.features.taskdetails.presentation.components.LoadingState
 import com.example.twdist_android.features.taskdetails.presentation.components.TaskDetailsHeaderCard
-import com.example.twdist_android.features.taskdetails.presentation.event.TaskDetailsEvent
 import com.example.twdist_android.features.taskdetails.presentation.model.TaskDetailsUi
 import com.example.twdist_android.features.taskdetails.presentation.model.TaskDetailsUiEvent
 import com.example.twdist_android.features.taskdetails.presentation.viewmodel.TaskDetailsViewModel
@@ -250,6 +252,39 @@ private fun TaskDetailsContent(
                 }
             )
         }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun TaskDetailsContentPreview() {
+    TWDistAndroidTheme {
+        TaskDetailsContent(
+            projectName = "University",
+            sectionId = 1L,
+            task = TaskDetailsUi(
+                id = 1L,
+                name = "Read chapter 3",
+                completed = false,
+                description = "Focus on exercises 1–5",
+                startDate = "2026-05-15",
+                endDate = "2026-05-20"
+            ),
+            isMenuOpen = false,
+            startDate = "2026-05-15",
+            endDate = "2026-05-20",
+            description = "Focus on exercises 1–5",
+            isSaving = false,
+            saveMessage = null,
+            openTaskMenuForId = null,
+            editingTaskId = null,
+            editingTaskName = "",
+            deleteConfirmTaskId = null,
+            taskActionError = null,
+            isTaskEditLoading = false,
+            isTaskDeleteLoading = false,
+            onEvent = {}
+        )
     }
 }
 

--- a/app/src/main/java/com/example/twdist_android/features/upcoming/presentation/screens/UpcomingScreen.kt
+++ b/app/src/main/java/com/example/twdist_android/features/upcoming/presentation/screens/UpcomingScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
@@ -30,13 +31,17 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.twdist_android.core.ui.components.task.TaskRowState
+import com.example.twdist_android.core.ui.theme.TWDistAndroidTheme
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.twdist_android.features.upcoming.presentation.components.UpcomingTaskList
 import com.example.twdist_android.features.upcoming.presentation.components.WeeklyCalendar
 import com.example.twdist_android.features.upcoming.presentation.model.UpcomingListItem
+import com.example.twdist_android.features.upcoming.presentation.model.UpcomingUiState
 import com.example.twdist_android.features.upcoming.presentation.model.UpcomingUiEvent
 import com.example.twdist_android.features.upcoming.presentation.viewmodel.UpcomingViewModel
 import kotlinx.coroutines.launch
@@ -112,7 +117,29 @@ fun UpcomingScreen(
         }
     }
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    UpcomingScreenContent(
+        uiState = uiState,
+        listState = listState,
+        calendarExpanded = calendarExpanded,
+        onToggleCalendarExpanded = { calendarExpanded = !calendarExpanded },
+        onDayClick = onDayClick,
+        onTaskCompleted = viewModel::onTaskCompleted,
+        snackbarHostState = snackbarHostState
+    )
+}
+
+@Composable
+fun UpcomingScreenContent(
+    uiState: UpcomingUiState,
+    listState: LazyListState,
+    calendarExpanded: Boolean,
+    onToggleCalendarExpanded: () -> Unit,
+    onDayClick: (LocalDate) -> Unit,
+    onTaskCompleted: (TaskRowState) -> Unit,
+    snackbarHostState: SnackbarHostState,
+    modifier: Modifier = Modifier
+) {
+    Box(modifier = modifier.fillMaxSize()) {
         Column(modifier = Modifier.fillMaxSize().padding(top = 16.dp)) {
             Text(
                 text = "Upcoming",
@@ -125,7 +152,7 @@ fun UpcomingScreen(
                 weekStart = uiState.weekStart,
                 visibleDate = uiState.visibleDate,
                 isExpanded = calendarExpanded,
-                onToggleExpanded = { calendarExpanded = !calendarExpanded },
+                onToggleExpanded = onToggleCalendarExpanded,
                 onDayClick = onDayClick
             )
             HorizontalDivider()
@@ -141,7 +168,7 @@ fun UpcomingScreen(
                 UpcomingTaskList(
                     items = uiState.items,
                     listState = listState,
-                    onTaskCompleted = viewModel::onTaskCompleted
+                    onTaskCompleted = onTaskCompleted
                 )
             }
 
@@ -159,6 +186,55 @@ fun UpcomingScreen(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
                 .padding(bottom = 8.dp)
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun UpcomingScreenContentPreview() {
+    val today = LocalDate.now()
+    TWDistAndroidTheme {
+        UpcomingScreenContent(
+            uiState = UpcomingUiState(
+                items = listOf(
+                    UpcomingListItem.Header(today),
+                    UpcomingListItem.Task(
+                        state = TaskRowState(
+                            id = 1L,
+                            projectId = 1L,
+                            sectionId = 1L,
+                            title = "Review notes",
+                            projectName = "University"
+                        ),
+                        date = today
+                    )
+                ),
+                visibleDate = today,
+                weekStart = today
+            ),
+            listState = rememberLazyListState(),
+            calendarExpanded = false,
+            onToggleCalendarExpanded = {},
+            onDayClick = {},
+            onTaskCompleted = {},
+            snackbarHostState = remember { SnackbarHostState() }
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun UpcomingScreenLoadingPreview() {
+    TWDistAndroidTheme {
+        UpcomingScreenContent(
+            uiState = UpcomingUiState(isLoading = true),
+            listState = rememberLazyListState(),
+            calendarExpanded = false,
+            onToggleCalendarExpanded = {},
+            onDayClick = {},
+            onTaskCompleted = {},
+            snackbarHostState = remember { SnackbarHostState() }
         )
     }
 }


### PR DESCRIPTION
Basically added some missing previews to the screens that needed them.

Ai summary:
Adds and fixes **Compose `@Preview`** support for screens that were missing previews or crashing in the Design panel. Follows the same pattern as Today: extract a **stateless content composable** and preview it with mock UI state (no Hilt/ViewModel).

## Changes

### Explore
- Introduced `ExploreScreenContent` with `ExploreUiState` and callbacks.
- `ExploreScreen` keeps ViewModel, lifecycle, and dialogs.
- **Fixed** `ExploreScreenPreview` — it previously called `ExploreScreen()` + `hiltViewModel()`, which crashed in preview (`Cannot create an instance of ExploreViewModel`).
- Added `ExploreScreenContentPreview` and `ExploreScreenLoadingPreview`.

### Favorite
- Extended `FavoriteProjectScreenPreview.kt` with previews for **`FavoriteProjectScreenContent`**:
  - With projects
  - Loading
  - Error
  - Empty

### Upcoming
- Extracted `UpcomingScreenContent`.
- Added content and loading previews.

### Project details & task details
- **Project details:** previews for content, loading, error, and missing project.
- **Task details:** `TaskDetailsContentPreview` plus loading/error in `TaskDetailsScreenStates`.