### PR TITLE
Feat/logout

### DIFF
--- a/app/src/main/java/com/example/twdist_android/core/ui/AuthGate.kt
+++ b/app/src/main/java/com/example/twdist_android/core/ui/AuthGate.kt
@@ -20,7 +20,10 @@ fun AuthGate(
     val sessionStatus by sessionViewModel.sessionStatus.collectAsState()
 
     Box(modifier = Modifier.fillMaxSize()) {
-        NavigationRoot(sessionStatus = sessionStatus)
+        NavigationRoot(
+            sessionStatus = sessionStatus,
+            onLogout = { sessionViewModel.logout() }
+        )
 
         if (sessionStatus is SessionStatus.Checking) {
             Box(

--- a/app/src/main/java/com/example/twdist_android/core/ui/AuthGate.kt
+++ b/app/src/main/java/com/example/twdist_android/core/ui/AuthGate.kt
@@ -18,11 +18,13 @@ fun AuthGate(
     sessionViewModel: SessionViewModel = hiltViewModel()
 ) {
     val sessionStatus by sessionViewModel.sessionStatus.collectAsState()
+    val isLoggingOut by sessionViewModel.isLoggingOut.collectAsState()
 
     Box(modifier = Modifier.fillMaxSize()) {
         NavigationRoot(
             sessionStatus = sessionStatus,
-            onLogout = { sessionViewModel.logout() }
+            onLogout = { sessionViewModel.logout() },
+            isLoggingOut = isLoggingOut
         )
 
         if (sessionStatus is SessionStatus.Checking) {

--- a/app/src/main/java/com/example/twdist_android/core/ui/components/ScreenHeader.kt
+++ b/app/src/main/java/com/example/twdist_android/core/ui/components/ScreenHeader.kt
@@ -1,0 +1,62 @@
+package com.example.twdist_android.core.ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ScreenHeader(
+    title: String,
+    onLogout: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var menuExpanded by remember { mutableStateOf(false) }
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        ScreenTitle(
+            text = title,
+            modifier = Modifier.weight(1f)
+        )
+        Box {
+            IconButton(onClick = { menuExpanded = true }) {
+                Icon(
+                    imageVector = Icons.Default.MoreVert,
+                    contentDescription = "More options"
+                )
+            }
+            DropdownMenu(
+                expanded = menuExpanded,
+                onDismissRequest = { menuExpanded = false }
+            ) {
+                DropdownMenuItem(
+                    text = { Text("Log out") },
+                    onClick = {
+                        menuExpanded = false
+                        onLogout()
+                    }
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/twdist_android/core/ui/components/ScreenHeader.kt
+++ b/app/src/main/java/com/example/twdist_android/core/ui/components/ScreenHeader.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -24,9 +25,16 @@ import androidx.compose.ui.unit.dp
 fun ScreenHeader(
     title: String,
     onLogout: () -> Unit,
+    isLoggingOut: Boolean = false,
     modifier: Modifier = Modifier
 ) {
     var menuExpanded by remember { mutableStateOf(false) }
+
+    LaunchedEffect(isLoggingOut) {
+        if (isLoggingOut) {
+            menuExpanded = false
+        }
+    }
 
     Row(
         modifier = modifier
@@ -39,18 +47,22 @@ fun ScreenHeader(
             modifier = Modifier.weight(1f)
         )
         Box {
-            IconButton(onClick = { menuExpanded = true }) {
+            IconButton(
+                onClick = { menuExpanded = true },
+                enabled = !isLoggingOut
+            ) {
                 Icon(
                     imageVector = Icons.Default.MoreVert,
                     contentDescription = "More options"
                 )
             }
             DropdownMenu(
-                expanded = menuExpanded,
+                expanded = menuExpanded && !isLoggingOut,
                 onDismissRequest = { menuExpanded = false }
             ) {
                 DropdownMenuItem(
                     text = { Text("Log out") },
+                    enabled = !isLoggingOut,
                     onClick = {
                         menuExpanded = false
                         onLogout()

--- a/app/src/main/java/com/example/twdist_android/core/ui/components/ScreenTitle.kt
+++ b/app/src/main/java/com/example/twdist_android/core/ui/components/ScreenTitle.kt
@@ -1,0 +1,21 @@
+package com.example.twdist_android.core.ui.components
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun ScreenTitle(
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        text = text,
+        fontSize = 30.sp,
+        fontWeight = FontWeight.W500,
+        modifier = modifier
+    )
+}

--- a/app/src/main/java/com/example/twdist_android/core/ui/navigation/NavigationRoot.kt
+++ b/app/src/main/java/com/example/twdist_android/core/ui/navigation/NavigationRoot.kt
@@ -60,7 +60,8 @@ data class TaskDetailsScreenKey(
 
 @Composable
 fun NavigationRoot(
-    sessionStatus: SessionStatus = SessionStatus.Unauthenticated
+    sessionStatus: SessionStatus = SessionStatus.Unauthenticated,
+    onLogout: () -> Unit = {}
 ) {
     val backStack = rememberNavBackStack(LoginScreenKey)
     var previousSessionStatus by remember { mutableStateOf<SessionStatus?>(null) }
@@ -96,12 +97,12 @@ fun NavigationRoot(
         entryProvider = entryProvider {
             entry<TodayScreenKey> {
                 AppScaffold(onNavItemClick = { (backStack as MutableList<NavKey>).add(it) }) {
-                    TodayScreen()
+                    TodayScreen(onLogout = onLogout)
                 }
             }
             entry<UpcomingScreenKey> {
                 AppScaffold(onNavItemClick = { (backStack as MutableList<NavKey>).add(it) }) {
-                    UpcomingScreen()
+                    UpcomingScreen(onLogout = onLogout)
                 }
             }
             entry<FavoriteScreenKey> {
@@ -109,7 +110,8 @@ fun NavigationRoot(
                     FavoriteProjectScreen(
                         onNavigateToProjectDetails = { projectId ->
                             backStack.add(ProjectDetailsScreenKey(projectId))
-                        }
+                        },
+                        onLogout = onLogout
                     )
                 }
             }
@@ -118,7 +120,8 @@ fun NavigationRoot(
                     ExploreScreen(
                         onNavigateToProjectDetails = { projectId ->
                             backStack.add(ProjectDetailsScreenKey(projectId))
-                        }
+                        },
+                        onLogout = onLogout
                     )
                 }
             }

--- a/app/src/main/java/com/example/twdist_android/core/ui/navigation/NavigationRoot.kt
+++ b/app/src/main/java/com/example/twdist_android/core/ui/navigation/NavigationRoot.kt
@@ -61,7 +61,8 @@ data class TaskDetailsScreenKey(
 @Composable
 fun NavigationRoot(
     sessionStatus: SessionStatus = SessionStatus.Unauthenticated,
-    onLogout: () -> Unit = {}
+    onLogout: () -> Unit = {},
+    isLoggingOut: Boolean = false
 ) {
     val backStack = rememberNavBackStack(LoginScreenKey)
     var previousSessionStatus by remember { mutableStateOf<SessionStatus?>(null) }
@@ -97,12 +98,12 @@ fun NavigationRoot(
         entryProvider = entryProvider {
             entry<TodayScreenKey> {
                 AppScaffold(onNavItemClick = { (backStack as MutableList<NavKey>).add(it) }) {
-                    TodayScreen(onLogout = onLogout)
+                    TodayScreen(onLogout = onLogout, isLoggingOut = isLoggingOut)
                 }
             }
             entry<UpcomingScreenKey> {
                 AppScaffold(onNavItemClick = { (backStack as MutableList<NavKey>).add(it) }) {
-                    UpcomingScreen(onLogout = onLogout)
+                    UpcomingScreen(onLogout = onLogout, isLoggingOut = isLoggingOut)
                 }
             }
             entry<FavoriteScreenKey> {
@@ -111,7 +112,8 @@ fun NavigationRoot(
                         onNavigateToProjectDetails = { projectId ->
                             backStack.add(ProjectDetailsScreenKey(projectId))
                         },
-                        onLogout = onLogout
+                        onLogout = onLogout,
+                        isLoggingOut = isLoggingOut
                     )
                 }
             }
@@ -121,7 +123,8 @@ fun NavigationRoot(
                         onNavigateToProjectDetails = { projectId ->
                             backStack.add(ProjectDetailsScreenKey(projectId))
                         },
-                        onLogout = onLogout
+                        onLogout = onLogout,
+                        isLoggingOut = isLoggingOut
                     )
                 }
             }

--- a/app/src/main/java/com/example/twdist_android/di/AuthModule.kt
+++ b/app/src/main/java/com/example/twdist_android/di/AuthModule.kt
@@ -2,6 +2,7 @@ package com.example.twdist_android.di
 
 import com.example.twdist_android.core.network.CookieJarImpl
 import com.example.twdist_android.features.auth.application.usecases.LoginUseCase
+import com.example.twdist_android.features.auth.application.usecases.LogoutUseCase
 import com.example.twdist_android.features.auth.application.usecases.RefreshSessionUseCase
 import com.example.twdist_android.features.auth.application.usecases.RegisterUseCase
 import com.example.twdist_android.features.auth.application.usecases.RestoreSessionUseCase
@@ -50,4 +51,11 @@ object AuthModule {
     @Singleton
     fun provideRefreshSessionUseCase(authRepository: AuthRepository): RefreshSessionUseCase =
         RefreshSessionUseCase(authRepository)
+
+    @Provides
+    @Singleton
+    fun provideLogoutUseCase(
+        authRepository: AuthRepository,
+        authSessionManager: com.example.twdist_android.features.auth.domain.session.AuthSessionManager
+    ): LogoutUseCase = LogoutUseCase(authRepository, authSessionManager)
 }

--- a/app/src/main/java/com/example/twdist_android/features/auth/application/usecases/LogoutUseCase.kt
+++ b/app/src/main/java/com/example/twdist_android/features/auth/application/usecases/LogoutUseCase.kt
@@ -1,0 +1,14 @@
+package com.example.twdist_android.features.auth.application.usecases
+
+import com.example.twdist_android.features.auth.domain.repository.AuthRepository
+import com.example.twdist_android.features.auth.domain.session.AuthSessionManager
+
+class LogoutUseCase(
+    private val authRepository: AuthRepository,
+    private val authSessionManager: AuthSessionManager
+) {
+    suspend operator fun invoke() {
+        authRepository.logout()
+        authSessionManager.setUnauthenticated()
+    }
+}

--- a/app/src/main/java/com/example/twdist_android/features/auth/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/example/twdist_android/features/auth/data/repository/AuthRepositoryImpl.kt
@@ -11,6 +11,7 @@ import com.example.twdist_android.features.auth.domain.model.LoginCredentials
 import com.example.twdist_android.features.auth.domain.model.RegisterCredentials
 import com.example.twdist_android.features.auth.domain.model.RegisteredUser
 import com.example.twdist_android.features.auth.domain.repository.AuthRepository
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
@@ -84,7 +85,8 @@ class AuthRepositoryImpl(
         withContext(Dispatchers.IO) {
             try {
                 api.logout()
-            } catch (_: Exception) {
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 // Still clear local session if the server is unreachable.
             } finally {
                 cookieJar.clearAll()

--- a/app/src/main/java/com/example/twdist_android/features/auth/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/example/twdist_android/features/auth/data/repository/AuthRepositoryImpl.kt
@@ -80,6 +80,18 @@ class AuthRepositoryImpl(
         }
     }
 
+    override suspend fun logout() {
+        withContext(Dispatchers.IO) {
+            try {
+                api.logout()
+            } catch (_: Exception) {
+                // Still clear local session if the server is unreachable.
+            } finally {
+                cookieJar.clearAll()
+            }
+        }
+    }
+
     override suspend fun clearLocalSession() {
         withContext(Dispatchers.IO) {
             cookieJar.clearAll()

--- a/app/src/main/java/com/example/twdist_android/features/auth/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/example/twdist_android/features/auth/domain/repository/AuthRepository.kt
@@ -9,5 +9,6 @@ interface AuthRepository {
     suspend fun sendLogin(credentials: LoginCredentials)
     suspend fun getCurrentUser(): Result<RegisteredUser>
     suspend fun refreshSession(): Result<Unit>
+    suspend fun logout()
     suspend fun clearLocalSession()
 }

--- a/app/src/main/java/com/example/twdist_android/features/auth/presentation/viewmodel/SessionViewModel.kt
+++ b/app/src/main/java/com/example/twdist_android/features/auth/presentation/viewmodel/SessionViewModel.kt
@@ -7,7 +7,9 @@ import com.example.twdist_android.features.auth.application.usecases.RestoreSess
 import com.example.twdist_android.features.auth.domain.model.SessionStatus
 import com.example.twdist_android.features.auth.domain.session.AuthSessionManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -20,6 +22,9 @@ class SessionViewModel @Inject constructor(
 
     val sessionStatus: StateFlow<SessionStatus> = authSessionManager.sessionStatus
 
+    private val _isLoggingOut = MutableStateFlow(false)
+    val isLoggingOut: StateFlow<Boolean> = _isLoggingOut.asStateFlow()
+
     init {
         viewModelScope.launch {
             restoreSessionUseCase()
@@ -27,8 +32,14 @@ class SessionViewModel @Inject constructor(
     }
 
     fun logout() {
+        if (_isLoggingOut.value) return
         viewModelScope.launch {
-            logoutUseCase()
+            _isLoggingOut.value = true
+            try {
+                logoutUseCase()
+            } finally {
+                _isLoggingOut.value = false
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/twdist_android/features/auth/presentation/viewmodel/SessionViewModel.kt
+++ b/app/src/main/java/com/example/twdist_android/features/auth/presentation/viewmodel/SessionViewModel.kt
@@ -2,6 +2,7 @@ package com.example.twdist_android.features.auth.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.twdist_android.features.auth.application.usecases.LogoutUseCase
 import com.example.twdist_android.features.auth.application.usecases.RestoreSessionUseCase
 import com.example.twdist_android.features.auth.domain.model.SessionStatus
 import com.example.twdist_android.features.auth.domain.session.AuthSessionManager
@@ -13,6 +14,7 @@ import javax.inject.Inject
 @HiltViewModel
 class SessionViewModel @Inject constructor(
     private val restoreSessionUseCase: RestoreSessionUseCase,
+    private val logoutUseCase: LogoutUseCase,
     authSessionManager: AuthSessionManager
 ) : ViewModel() {
 
@@ -21,6 +23,12 @@ class SessionViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             restoreSessionUseCase()
+        }
+    }
+
+    fun logout() {
+        viewModelScope.launch {
+            logoutUseCase()
         }
     }
 }

--- a/app/src/main/java/com/example/twdist_android/features/auth/presentation/viewmodel/SessionViewModel.kt
+++ b/app/src/main/java/com/example/twdist_android/features/auth/presentation/viewmodel/SessionViewModel.kt
@@ -33,8 +33,8 @@ class SessionViewModel @Inject constructor(
 
     fun logout() {
         if (_isLoggingOut.value) return
+        _isLoggingOut.value = true
         viewModelScope.launch {
-            _isLoggingOut.value = true
             try {
                 logoutUseCase()
             } finally {

--- a/app/src/main/java/com/example/twdist_android/features/explore/presentation/components/SectionHeader.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/presentation/components/SectionHeader.kt
@@ -26,7 +26,7 @@ fun SectionHeader(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(vertical = 8.dp),
+            .padding(top = 4.dp, bottom = 8.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/app/src/main/java/com/example/twdist_android/features/explore/presentation/screens/ExploreScreen.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/presentation/screens/ExploreScreen.kt
@@ -28,7 +28,6 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.twdist_android.core.ui.components.ScreenHeader
-import com.example.twdist_android.features.auth.presentation.viewmodel.SessionViewModel
 import com.example.twdist_android.core.ui.theme.TWDistAndroidTheme
 import com.example.twdist_android.features.explore.presentation.components.CreateProjectDialog
 import com.example.twdist_android.features.explore.presentation.components.DeleteProjectDialog
@@ -41,9 +40,9 @@ import com.example.twdist_android.features.explore.presentation.viewmodel.Explor
 
 @Composable
 fun ExploreScreen(
+    onLogout: () -> Unit,
     onNavigateToProjectDetails: (Long) -> Unit = {},
-    viewModel: ExploreViewModel = hiltViewModel(),
-    sessionViewModel: SessionViewModel = hiltViewModel()
+    viewModel: ExploreViewModel = hiltViewModel()
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -79,7 +78,7 @@ fun ExploreScreen(
         onSwipeDelete = { projectId ->
             viewModel.handleEvent(ExploreEvent.ShowDeleteProjectConfirmation(projectId))
         },
-        onLogout = { sessionViewModel.logout() }
+        onLogout = onLogout
     )
 
     if (showCreateDialog) {

--- a/app/src/main/java/com/example/twdist_android/features/explore/presentation/screens/ExploreScreen.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/presentation/screens/ExploreScreen.kt
@@ -41,6 +41,7 @@ import com.example.twdist_android.features.explore.presentation.viewmodel.Explor
 @Composable
 fun ExploreScreen(
     onLogout: () -> Unit,
+    isLoggingOut: Boolean = false,
     onNavigateToProjectDetails: (Long) -> Unit = {},
     viewModel: ExploreViewModel = hiltViewModel()
 ) {
@@ -78,7 +79,8 @@ fun ExploreScreen(
         onSwipeDelete = { projectId ->
             viewModel.handleEvent(ExploreEvent.ShowDeleteProjectConfirmation(projectId))
         },
-        onLogout = onLogout
+        onLogout = onLogout,
+        isLoggingOut = isLoggingOut
     )
 
     if (showCreateDialog) {
@@ -110,6 +112,7 @@ fun ExploreScreenContent(
     onToggleFavorite: (Long) -> Unit,
     onSwipeDelete: (Long) -> Unit,
     onLogout: () -> Unit,
+    isLoggingOut: Boolean = false,
     modifier: Modifier = Modifier
 ) {
     Box(modifier = modifier.fillMaxSize()) {
@@ -121,7 +124,8 @@ fun ExploreScreenContent(
         ) {
             ScreenHeader(
                 title = "Explore",
-                onLogout = onLogout
+                onLogout = onLogout,
+                isLoggingOut = isLoggingOut
             )
             Spacer(modifier = Modifier.height(8.dp))
             SectionHeader(

--- a/app/src/main/java/com/example/twdist_android/features/explore/presentation/screens/ExploreScreen.kt
+++ b/app/src/main/java/com/example/twdist_android/features/explore/presentation/screens/ExploreScreen.kt
@@ -3,8 +3,10 @@ package com.example.twdist_android.features.explore.presentation.screens
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -25,6 +27,8 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.twdist_android.core.ui.components.ScreenHeader
+import com.example.twdist_android.features.auth.presentation.viewmodel.SessionViewModel
 import com.example.twdist_android.core.ui.theme.TWDistAndroidTheme
 import com.example.twdist_android.features.explore.presentation.components.CreateProjectDialog
 import com.example.twdist_android.features.explore.presentation.components.DeleteProjectDialog
@@ -38,7 +42,8 @@ import com.example.twdist_android.features.explore.presentation.viewmodel.Explor
 @Composable
 fun ExploreScreen(
     onNavigateToProjectDetails: (Long) -> Unit = {},
-    viewModel: ExploreViewModel = hiltViewModel()
+    viewModel: ExploreViewModel = hiltViewModel(),
+    sessionViewModel: SessionViewModel = hiltViewModel()
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -73,7 +78,8 @@ fun ExploreScreen(
         },
         onSwipeDelete = { projectId ->
             viewModel.handleEvent(ExploreEvent.ShowDeleteProjectConfirmation(projectId))
-        }
+        },
+        onLogout = { sessionViewModel.logout() }
     )
 
     if (showCreateDialog) {
@@ -104,6 +110,7 @@ fun ExploreScreenContent(
     onAddClick: () -> Unit,
     onToggleFavorite: (Long) -> Unit,
     onSwipeDelete: (Long) -> Unit,
+    onLogout: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Box(modifier = modifier.fillMaxSize()) {
@@ -111,13 +118,19 @@ fun ExploreScreenContent(
             modifier = Modifier
                 .fillMaxSize()
                 .background(MaterialTheme.colorScheme.background)
-                .padding(16.dp)
+                .padding(top = 16.dp)
         ) {
+            ScreenHeader(
+                title = "Explore",
+                onLogout = onLogout
+            )
+            Spacer(modifier = Modifier.height(8.dp))
             SectionHeader(
                 title = "My projects",
                 isExpanded = state.isExpanded,
                 onExpandClick = onToggleExpanded,
-                onAddClick = onAddClick
+                onAddClick = onAddClick,
+                modifier = Modifier.padding(horizontal = 16.dp)
             )
 
             if (state.isExpanded) {
@@ -139,6 +152,7 @@ fun ExploreScreenContent(
                         modifier = Modifier
                             .fillMaxWidth()
                             .weight(1f)
+                            .padding(horizontal = 16.dp)
                     )
                 }
             }
@@ -169,7 +183,8 @@ private fun ExploreScreenContentPreview() {
             onToggleExpanded = {},
             onAddClick = {},
             onToggleFavorite = {},
-            onSwipeDelete = {}
+            onSwipeDelete = {},
+            onLogout = {}
         )
     }
 }
@@ -184,7 +199,8 @@ private fun ExploreScreenLoadingPreview() {
             onToggleExpanded = {},
             onAddClick = {},
             onToggleFavorite = {},
-            onSwipeDelete = {}
+            onSwipeDelete = {},
+            onLogout = {}
         )
     }
 }

--- a/app/src/main/java/com/example/twdist_android/features/favorite/presentation/components/EmptyState.kt
+++ b/app/src/main/java/com/example/twdist_android/features/favorite/presentation/components/EmptyState.kt
@@ -2,9 +2,7 @@ package com.example.twdist_android.features.favorite.presentation.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -22,11 +20,6 @@ internal fun EmptyState() {
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Text(
-            text = "Favorite projects",
-            style = MaterialTheme.typography.headlineSmall
-        )
-        Spacer(modifier = Modifier.height(8.dp))
         Text(
             text = "You have no favorite projects yet.",
             style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/java/com/example/twdist_android/features/favorite/presentation/components/FavoriteContent.kt
+++ b/app/src/main/java/com/example/twdist_android/features/favorite/presentation/components/FavoriteContent.kt
@@ -28,10 +28,10 @@ internal fun FavoriteContent(
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
-            .padding(16.dp)
+            .padding(horizontal = 16.dp)
     ) {
         SectionHeader(
-            title = "Favorite projects",
+            title = "My projects",
             isExpanded = isExpanded,
             onExpandClick = { isExpanded = !isExpanded },
             onAddClick = {},

--- a/app/src/main/java/com/example/twdist_android/features/favorite/presentation/components/FavoriteProjectScreenContent.kt
+++ b/app/src/main/java/com/example/twdist_android/features/favorite/presentation/components/FavoriteProjectScreenContent.kt
@@ -1,7 +1,10 @@
 package com.example.twdist_android.features.favorite.presentation.components
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -9,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.example.twdist_android.core.ui.components.ScreenHeader
 import com.example.twdist_android.features.favorite.presentation.model.FavoriteProjectsUiState
 
 @Composable
@@ -17,21 +21,35 @@ internal fun FavoriteProjectScreenContent(
     snackbarHostState: SnackbarHostState,
     onProjectClick: (Long) -> Unit,
     onRetry: () -> Unit,
-    onUnfavoriteClick: (Long) -> Unit
+    onUnfavoriteClick: (Long) -> Unit,
+    onLogout: () -> Unit
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
-        when {
-            uiState.isLoading && uiState.projects.isEmpty() -> LoadingState()
-            uiState.error != null && uiState.projects.isEmpty() -> ErrorState(
-                message = uiState.error ?: "Unknown error",
-                onRetry = onRetry
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(top = 16.dp)
+        ) {
+            ScreenHeader(
+                title = "Favorites",
+                onLogout = onLogout
             )
-            uiState.projects.isEmpty() -> EmptyState()
-            else -> FavoriteContent(
-                uiState = uiState,
-                onProjectClick = onProjectClick,
-                onUnfavoriteClick = onUnfavoriteClick
-            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Box(modifier = Modifier.weight(1f)) {
+                when {
+                    uiState.isLoading && uiState.projects.isEmpty() -> LoadingState()
+                    uiState.error != null && uiState.projects.isEmpty() -> ErrorState(
+                        message = uiState.error ?: "Unknown error",
+                        onRetry = onRetry
+                    )
+                    uiState.projects.isEmpty() -> EmptyState()
+                    else -> FavoriteContent(
+                        uiState = uiState,
+                        onProjectClick = onProjectClick,
+                        onUnfavoriteClick = onUnfavoriteClick
+                    )
+                }
+            }
         }
 
         uiState.error?.let { message ->

--- a/app/src/main/java/com/example/twdist_android/features/favorite/presentation/components/FavoriteProjectScreenContent.kt
+++ b/app/src/main/java/com/example/twdist_android/features/favorite/presentation/components/FavoriteProjectScreenContent.kt
@@ -22,7 +22,8 @@ internal fun FavoriteProjectScreenContent(
     onProjectClick: (Long) -> Unit,
     onRetry: () -> Unit,
     onUnfavoriteClick: (Long) -> Unit,
-    onLogout: () -> Unit
+    onLogout: () -> Unit,
+    isLoggingOut: Boolean = false
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
         Column(
@@ -32,7 +33,8 @@ internal fun FavoriteProjectScreenContent(
         ) {
             ScreenHeader(
                 title = "Favorites",
-                onLogout = onLogout
+                onLogout = onLogout,
+                isLoggingOut = isLoggingOut
             )
             Spacer(modifier = Modifier.height(8.dp))
             Box(modifier = Modifier.weight(1f)) {

--- a/app/src/main/java/com/example/twdist_android/features/favorite/presentation/components/FavoriteProjectScreenPreview.kt
+++ b/app/src/main/java/com/example/twdist_android/features/favorite/presentation/components/FavoriteProjectScreenPreview.kt
@@ -22,7 +22,8 @@ internal fun FavoriteProjectScreenContentPreview() {
             snackbarHostState = remember { SnackbarHostState() },
             onProjectClick = {},
             onRetry = {},
-            onUnfavoriteClick = {}
+            onUnfavoriteClick = {},
+            onLogout = {}
         )
     }
 }
@@ -36,7 +37,8 @@ internal fun FavoriteProjectScreenLoadingPreview() {
             snackbarHostState = remember { SnackbarHostState() },
             onProjectClick = {},
             onRetry = {},
-            onUnfavoriteClick = {}
+            onUnfavoriteClick = {},
+            onLogout = {}
         )
     }
 }
@@ -53,7 +55,8 @@ internal fun FavoriteProjectScreenErrorPreview() {
             snackbarHostState = remember { SnackbarHostState() },
             onProjectClick = {},
             onRetry = {},
-            onUnfavoriteClick = {}
+            onUnfavoriteClick = {},
+            onLogout = {}
         )
     }
 }
@@ -67,7 +70,8 @@ internal fun FavoriteProjectScreenEmptyPreview() {
             snackbarHostState = remember { SnackbarHostState() },
             onProjectClick = {},
             onRetry = {},
-            onUnfavoriteClick = {}
+            onUnfavoriteClick = {},
+            onLogout = {}
         )
     }
 }

--- a/app/src/main/java/com/example/twdist_android/features/favorite/presentation/screens/FavoriteProjectScreen.kt
+++ b/app/src/main/java/com/example/twdist_android/features/favorite/presentation/screens/FavoriteProjectScreen.kt
@@ -11,14 +11,13 @@ import com.example.twdist_android.features.favorite.presentation.components.Favo
 import com.example.twdist_android.features.favorite.presentation.components.FavoriteProjectsLifecycleEffect
 import com.example.twdist_android.features.favorite.presentation.components.FavoriteUndoSnackbarEffect
 import com.example.twdist_android.features.favorite.presentation.event.FavoriteProjectsEvent
-import com.example.twdist_android.features.auth.presentation.viewmodel.SessionViewModel
 import com.example.twdist_android.features.favorite.presentation.viewmodel.FavoriteProjectsViewModel
 
 @Composable
 fun FavoriteProjectScreen(
+    onLogout: () -> Unit,
     onNavigateToProjectDetails: (Long) -> Unit = {},
-    viewModel: FavoriteProjectsViewModel = hiltViewModel(),
-    sessionViewModel: SessionViewModel = hiltViewModel()
+    viewModel: FavoriteProjectsViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -45,6 +44,6 @@ fun FavoriteProjectScreen(
         onUnfavoriteClick = { projectId ->
             viewModel.handleEvent(FavoriteProjectsEvent.UnfavoriteProject(projectId))
         },
-        onLogout = { sessionViewModel.logout() }
+        onLogout = onLogout
     )
 }

--- a/app/src/main/java/com/example/twdist_android/features/favorite/presentation/screens/FavoriteProjectScreen.kt
+++ b/app/src/main/java/com/example/twdist_android/features/favorite/presentation/screens/FavoriteProjectScreen.kt
@@ -16,6 +16,7 @@ import com.example.twdist_android.features.favorite.presentation.viewmodel.Favor
 @Composable
 fun FavoriteProjectScreen(
     onLogout: () -> Unit,
+    isLoggingOut: Boolean = false,
     onNavigateToProjectDetails: (Long) -> Unit = {},
     viewModel: FavoriteProjectsViewModel = hiltViewModel()
 ) {
@@ -44,6 +45,7 @@ fun FavoriteProjectScreen(
         onUnfavoriteClick = { projectId ->
             viewModel.handleEvent(FavoriteProjectsEvent.UnfavoriteProject(projectId))
         },
-        onLogout = onLogout
+        onLogout = onLogout,
+        isLoggingOut = isLoggingOut
     )
 }

--- a/app/src/main/java/com/example/twdist_android/features/favorite/presentation/screens/FavoriteProjectScreen.kt
+++ b/app/src/main/java/com/example/twdist_android/features/favorite/presentation/screens/FavoriteProjectScreen.kt
@@ -11,12 +11,14 @@ import com.example.twdist_android.features.favorite.presentation.components.Favo
 import com.example.twdist_android.features.favorite.presentation.components.FavoriteProjectsLifecycleEffect
 import com.example.twdist_android.features.favorite.presentation.components.FavoriteUndoSnackbarEffect
 import com.example.twdist_android.features.favorite.presentation.event.FavoriteProjectsEvent
+import com.example.twdist_android.features.auth.presentation.viewmodel.SessionViewModel
 import com.example.twdist_android.features.favorite.presentation.viewmodel.FavoriteProjectsViewModel
 
 @Composable
 fun FavoriteProjectScreen(
     onNavigateToProjectDetails: (Long) -> Unit = {},
-    viewModel: FavoriteProjectsViewModel = hiltViewModel()
+    viewModel: FavoriteProjectsViewModel = hiltViewModel(),
+    sessionViewModel: SessionViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -42,6 +44,7 @@ fun FavoriteProjectScreen(
         onRetry = { viewModel.handleEvent(FavoriteProjectsEvent.LoadProjects) },
         onUnfavoriteClick = { projectId ->
             viewModel.handleEvent(FavoriteProjectsEvent.UnfavoriteProject(projectId))
-        }
+        },
+        onLogout = { sessionViewModel.logout() }
     )
 }

--- a/app/src/main/java/com/example/twdist_android/features/today/presentation/screens/TodayScreen.kt
+++ b/app/src/main/java/com/example/twdist_android/features/today/presentation/screens/TodayScreen.kt
@@ -31,7 +31,9 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.twdist_android.core.ui.components.ScreenHeader
 import com.example.twdist_android.core.ui.components.task.TaskRowState
+import com.example.twdist_android.features.auth.presentation.viewmodel.SessionViewModel
 import com.example.twdist_android.features.today.presentation.components.TodayTaskList
 import com.example.twdist_android.features.today.presentation.model.TodayUiEvent
 import com.example.twdist_android.features.today.presentation.model.TodayUiState
@@ -39,7 +41,8 @@ import com.example.twdist_android.features.today.presentation.viewmodel.TodayVie
 
 @Composable
 fun TodayScreen(
-    viewModel: TodayViewModel = hiltViewModel()
+    viewModel: TodayViewModel = hiltViewModel(),
+    sessionViewModel: SessionViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -78,6 +81,7 @@ fun TodayScreen(
         TodayScreenContent(
             uiState = uiState,
             onTaskCompleted = viewModel::onTaskCompleted,
+            onLogout = { sessionViewModel.logout() },
             modifier = Modifier
         )
         SnackbarHost(
@@ -93,6 +97,7 @@ fun TodayScreen(
 fun TodayScreenContent(
     uiState: TodayUiState,
     onTaskCompleted: (TaskRowState) -> Unit,
+    onLogout: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -100,11 +105,9 @@ fun TodayScreenContent(
             .fillMaxSize()
             .padding(top = 16.dp)
     ) {
-        Text(
-            text = uiState.title,
-            fontSize = 30.sp,
-            fontWeight = FontWeight.W500,
-            modifier = Modifier.padding(horizontal = 16.dp)
+        ScreenHeader(
+            title = uiState.title,
+            onLogout = onLogout
         )
         Spacer(modifier = Modifier.height(8.dp))
         Text(
@@ -173,6 +176,7 @@ fun TodayScreenContentPreview() {
                 )
             )
         ),
-        onTaskCompleted = {}
+        onTaskCompleted = {},
+        onLogout = {}
     )
 }

--- a/app/src/main/java/com/example/twdist_android/features/today/presentation/screens/TodayScreen.kt
+++ b/app/src/main/java/com/example/twdist_android/features/today/presentation/screens/TodayScreen.kt
@@ -33,7 +33,6 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.twdist_android.core.ui.components.ScreenHeader
 import com.example.twdist_android.core.ui.components.task.TaskRowState
-import com.example.twdist_android.features.auth.presentation.viewmodel.SessionViewModel
 import com.example.twdist_android.features.today.presentation.components.TodayTaskList
 import com.example.twdist_android.features.today.presentation.model.TodayUiEvent
 import com.example.twdist_android.features.today.presentation.model.TodayUiState
@@ -41,8 +40,8 @@ import com.example.twdist_android.features.today.presentation.viewmodel.TodayVie
 
 @Composable
 fun TodayScreen(
-    viewModel: TodayViewModel = hiltViewModel(),
-    sessionViewModel: SessionViewModel = hiltViewModel()
+    onLogout: () -> Unit,
+    viewModel: TodayViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -81,7 +80,7 @@ fun TodayScreen(
         TodayScreenContent(
             uiState = uiState,
             onTaskCompleted = viewModel::onTaskCompleted,
-            onLogout = { sessionViewModel.logout() },
+            onLogout = onLogout,
             modifier = Modifier
         )
         SnackbarHost(

--- a/app/src/main/java/com/example/twdist_android/features/today/presentation/screens/TodayScreen.kt
+++ b/app/src/main/java/com/example/twdist_android/features/today/presentation/screens/TodayScreen.kt
@@ -41,6 +41,7 @@ import com.example.twdist_android.features.today.presentation.viewmodel.TodayVie
 @Composable
 fun TodayScreen(
     onLogout: () -> Unit,
+    isLoggingOut: Boolean = false,
     viewModel: TodayViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -81,6 +82,7 @@ fun TodayScreen(
             uiState = uiState,
             onTaskCompleted = viewModel::onTaskCompleted,
             onLogout = onLogout,
+            isLoggingOut = isLoggingOut,
             modifier = Modifier
         )
         SnackbarHost(
@@ -97,6 +99,7 @@ fun TodayScreenContent(
     uiState: TodayUiState,
     onTaskCompleted: (TaskRowState) -> Unit,
     onLogout: () -> Unit,
+    isLoggingOut: Boolean = false,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -106,7 +109,8 @@ fun TodayScreenContent(
     ) {
         ScreenHeader(
             title = uiState.title,
-            onLogout = onLogout
+            onLogout = onLogout,
+            isLoggingOut = isLoggingOut
         )
         Spacer(modifier = Modifier.height(8.dp))
         Text(

--- a/app/src/main/java/com/example/twdist_android/features/upcoming/presentation/screens/UpcomingScreen.kt
+++ b/app/src/main/java/com/example/twdist_android/features/upcoming/presentation/screens/UpcomingScreen.kt
@@ -51,6 +51,7 @@ import java.time.LocalDate
 @Composable
 fun UpcomingScreen(
     onLogout: () -> Unit,
+    isLoggingOut: Boolean = false,
     viewModel: UpcomingViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -127,6 +128,7 @@ fun UpcomingScreen(
         onDayClick = onDayClick,
         onTaskCompleted = viewModel::onTaskCompleted,
         onLogout = onLogout,
+        isLoggingOut = isLoggingOut,
         snackbarHostState = snackbarHostState
     )
 }
@@ -140,6 +142,7 @@ fun UpcomingScreenContent(
     onDayClick: (LocalDate) -> Unit,
     onTaskCompleted: (TaskRowState) -> Unit,
     onLogout: () -> Unit,
+    isLoggingOut: Boolean = false,
     snackbarHostState: SnackbarHostState,
     modifier: Modifier = Modifier
 ) {
@@ -147,7 +150,8 @@ fun UpcomingScreenContent(
         Column(modifier = Modifier.fillMaxSize().padding(top = 16.dp)) {
             ScreenHeader(
                 title = "Upcoming",
-                onLogout = onLogout
+                onLogout = onLogout,
+                isLoggingOut = isLoggingOut
             )
             Spacer(modifier = Modifier.height(16.dp))
             WeeklyCalendar(

--- a/app/src/main/java/com/example/twdist_android/features/upcoming/presentation/screens/UpcomingScreen.kt
+++ b/app/src/main/java/com/example/twdist_android/features/upcoming/presentation/screens/UpcomingScreen.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.twdist_android.core.ui.components.ScreenHeader
 import com.example.twdist_android.core.ui.components.task.TaskRowState
-import com.example.twdist_android.features.auth.presentation.viewmodel.SessionViewModel
 import com.example.twdist_android.core.ui.theme.TWDistAndroidTheme
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -51,8 +50,8 @@ import java.time.LocalDate
 
 @Composable
 fun UpcomingScreen(
-    viewModel: UpcomingViewModel = hiltViewModel(),
-    sessionViewModel: SessionViewModel = hiltViewModel()
+    onLogout: () -> Unit,
+    viewModel: UpcomingViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val listState = rememberLazyListState()
@@ -127,7 +126,7 @@ fun UpcomingScreen(
         onToggleCalendarExpanded = { calendarExpanded = !calendarExpanded },
         onDayClick = onDayClick,
         onTaskCompleted = viewModel::onTaskCompleted,
-        onLogout = { sessionViewModel.logout() },
+        onLogout = onLogout,
         snackbarHostState = snackbarHostState
     )
 }

--- a/app/src/main/java/com/example/twdist_android/features/upcoming/presentation/screens/UpcomingScreen.kt
+++ b/app/src/main/java/com/example/twdist_android/features/upcoming/presentation/screens/UpcomingScreen.kt
@@ -34,7 +34,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.twdist_android.core.ui.components.ScreenHeader
 import com.example.twdist_android.core.ui.components.task.TaskRowState
+import com.example.twdist_android.features.auth.presentation.viewmodel.SessionViewModel
 import com.example.twdist_android.core.ui.theme.TWDistAndroidTheme
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -49,7 +51,8 @@ import java.time.LocalDate
 
 @Composable
 fun UpcomingScreen(
-    viewModel: UpcomingViewModel = hiltViewModel()
+    viewModel: UpcomingViewModel = hiltViewModel(),
+    sessionViewModel: SessionViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val listState = rememberLazyListState()
@@ -124,6 +127,7 @@ fun UpcomingScreen(
         onToggleCalendarExpanded = { calendarExpanded = !calendarExpanded },
         onDayClick = onDayClick,
         onTaskCompleted = viewModel::onTaskCompleted,
+        onLogout = { sessionViewModel.logout() },
         snackbarHostState = snackbarHostState
     )
 }
@@ -136,16 +140,15 @@ fun UpcomingScreenContent(
     onToggleCalendarExpanded: () -> Unit,
     onDayClick: (LocalDate) -> Unit,
     onTaskCompleted: (TaskRowState) -> Unit,
+    onLogout: () -> Unit,
     snackbarHostState: SnackbarHostState,
     modifier: Modifier = Modifier
 ) {
     Box(modifier = modifier.fillMaxSize()) {
         Column(modifier = Modifier.fillMaxSize().padding(top = 16.dp)) {
-            Text(
-                text = "Upcoming",
-                fontSize = 30.sp,
-                fontWeight = FontWeight.W500,
-                modifier = Modifier.padding(horizontal = 16.dp)
+            ScreenHeader(
+                title = "Upcoming",
+                onLogout = onLogout
             )
             Spacer(modifier = Modifier.height(16.dp))
             WeeklyCalendar(
@@ -218,6 +221,7 @@ private fun UpcomingScreenContentPreview() {
             onToggleCalendarExpanded = {},
             onDayClick = {},
             onTaskCompleted = {},
+            onLogout = {},
             snackbarHostState = remember { SnackbarHostState() }
         )
     }
@@ -234,6 +238,7 @@ private fun UpcomingScreenLoadingPreview() {
             onToggleCalendarExpanded = {},
             onDayClick = {},
             onTaskCompleted = {},
+            onLogout = {},
             snackbarHostState = remember { SnackbarHostState() }
         )
     }

--- a/app/src/test/java/com/example/twdist_android/features/auth/data/repository/AuthRepositoryImplTest.kt
+++ b/app/src/test/java/com/example/twdist_android/features/auth/data/repository/AuthRepositoryImplTest.kt
@@ -7,7 +7,10 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
+import java.io.IOException
+import org.junit.Assert.fail
 import kotlinx.serialization.json.Json
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
@@ -64,6 +67,29 @@ class AuthRepositoryImplTest {
     @Test
     fun `clearLocalSession clears cookie jar`() = runTest {
         repository.clearLocalSession()
+
+        verify(exactly = 1) { cookieJar.clearAll() }
+    }
+
+    @Test
+    fun `logout clears cookies when api fails`() = runTest {
+        coEvery { api.logout() } throws IOException("network")
+
+        repository.logout()
+
+        verify(exactly = 1) { cookieJar.clearAll() }
+    }
+
+    @Test
+    fun `logout rethrows cancellation`() = runTest {
+        coEvery { api.logout() } throws CancellationException()
+
+        try {
+            repository.logout()
+            fail("Expected CancellationException")
+        } catch (_: CancellationException) {
+            // expected
+        }
 
         verify(exactly = 1) { cookieJar.clearAll() }
     }

--- a/app/src/test/java/com/example/twdist_android/features/auth/presentation/viewmodel/SessionViewModelTest.kt
+++ b/app/src/test/java/com/example/twdist_android/features/auth/presentation/viewmodel/SessionViewModelTest.kt
@@ -6,6 +6,7 @@ import com.example.twdist_android.features.auth.domain.model.RegisteredUser
 import com.example.twdist_android.features.auth.domain.model.SessionStatus
 import com.example.twdist_android.features.auth.domain.session.AuthSessionManager
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -16,6 +17,9 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import kotlinx.coroutines.delay
 import org.junit.Before
 import org.junit.Test
 
@@ -59,5 +63,38 @@ class SessionViewModelTest {
         advanceUntilIdle()
 
         assertEquals(SessionStatus.Unauthenticated, viewModel.sessionStatus.value)
+    }
+
+    @Test
+    fun `logout sets isLoggingOut while use case runs`() = runTest {
+        coEvery { logoutUseCase() } coAnswers {
+            delay(100)
+        }
+
+        val viewModel = SessionViewModel(restoreSessionUseCase, logoutUseCase, authSessionManager)
+        advanceUntilIdle()
+        assertFalse(viewModel.isLoggingOut.value)
+
+        viewModel.logout()
+        assertTrue(viewModel.isLoggingOut.value)
+
+        advanceUntilIdle()
+        assertFalse(viewModel.isLoggingOut.value)
+    }
+
+    @Test
+    fun `logout ignores duplicate calls while in progress`() = runTest {
+        coEvery { logoutUseCase() } coAnswers {
+            delay(100)
+        }
+
+        val viewModel = SessionViewModel(restoreSessionUseCase, logoutUseCase, authSessionManager)
+        advanceUntilIdle()
+
+        viewModel.logout()
+        viewModel.logout()
+
+        advanceUntilIdle()
+        coVerify(exactly = 1) { logoutUseCase() }
     }
 }

--- a/app/src/test/java/com/example/twdist_android/features/auth/presentation/viewmodel/SessionViewModelTest.kt
+++ b/app/src/test/java/com/example/twdist_android/features/auth/presentation/viewmodel/SessionViewModelTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
@@ -41,7 +42,7 @@ class SessionViewModelTest {
     }
 
     @Test
-    fun `init restores session and exposes authenticated status`() = runTest {
+    fun `init restores session and exposes authenticated status`() = runTest(testDispatcher) {
         val user = RegisteredUser(id = 1L, username = "test", email = "user@email.com")
         coEvery { restoreSessionUseCase() } coAnswers {
             authSessionManager.setAuthenticated(user)
@@ -54,7 +55,7 @@ class SessionViewModelTest {
     }
 
     @Test
-    fun `init restores session and exposes unauthenticated status`() = runTest {
+    fun `init restores session and exposes unauthenticated status`() = runTest(testDispatcher) {
         coEvery { restoreSessionUseCase() } coAnswers {
             authSessionManager.setUnauthenticated()
         }
@@ -66,7 +67,7 @@ class SessionViewModelTest {
     }
 
     @Test
-    fun `logout sets isLoggingOut while use case runs`() = runTest {
+    fun `logout sets isLoggingOut while use case runs`() = runTest(testDispatcher) {
         coEvery { logoutUseCase() } coAnswers {
             delay(100)
         }
@@ -76,6 +77,7 @@ class SessionViewModelTest {
         assertFalse(viewModel.isLoggingOut.value)
 
         viewModel.logout()
+        runCurrent()
         assertTrue(viewModel.isLoggingOut.value)
 
         advanceUntilIdle()
@@ -83,7 +85,7 @@ class SessionViewModelTest {
     }
 
     @Test
-    fun `logout ignores duplicate calls while in progress`() = runTest {
+    fun `logout ignores duplicate calls while in progress`() = runTest(testDispatcher) {
         coEvery { logoutUseCase() } coAnswers {
             delay(100)
         }
@@ -93,6 +95,7 @@ class SessionViewModelTest {
 
         viewModel.logout()
         viewModel.logout()
+        runCurrent()
 
         advanceUntilIdle()
         coVerify(exactly = 1) { logoutUseCase() }

--- a/app/src/test/java/com/example/twdist_android/features/auth/presentation/viewmodel/SessionViewModelTest.kt
+++ b/app/src/test/java/com/example/twdist_android/features/auth/presentation/viewmodel/SessionViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.example.twdist_android.features.auth.presentation.viewmodel
 
+import com.example.twdist_android.features.auth.application.usecases.LogoutUseCase
 import com.example.twdist_android.features.auth.application.usecases.RestoreSessionUseCase
 import com.example.twdist_android.features.auth.domain.model.RegisteredUser
 import com.example.twdist_android.features.auth.domain.model.SessionStatus
@@ -22,6 +23,7 @@ import org.junit.Test
 class SessionViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
     private val restoreSessionUseCase: RestoreSessionUseCase = mockk(relaxed = true)
+    private val logoutUseCase: LogoutUseCase = mockk(relaxed = true)
     private val authSessionManager = AuthSessionManager()
 
     @Before
@@ -41,7 +43,7 @@ class SessionViewModelTest {
             authSessionManager.setAuthenticated(user)
         }
 
-        val viewModel = SessionViewModel(restoreSessionUseCase, authSessionManager)
+        val viewModel = SessionViewModel(restoreSessionUseCase, logoutUseCase, authSessionManager)
         advanceUntilIdle()
 
         assertEquals(SessionStatus.Authenticated(user), viewModel.sessionStatus.value)
@@ -53,7 +55,7 @@ class SessionViewModelTest {
             authSessionManager.setUnauthenticated()
         }
 
-        val viewModel = SessionViewModel(restoreSessionUseCase, authSessionManager)
+        val viewModel = SessionViewModel(restoreSessionUseCase, logoutUseCase, authSessionManager)
         advanceUntilIdle()
 
         assertEquals(SessionStatus.Unauthenticated, viewModel.sessionStatus.value)


### PR DESCRIPTION
Basically added a big title screens on Explore and My favorites like on Today and Upcoming screens, also installed a three-dot vertical menu button to the right of every tab title with the option to do log out. 

Visual changes
| :---: |
 |<img width="428" height="847" alt="image" src="https://github.com/user-attachments/assets/6dce35b7-f6b2-4077-b9ce-4e00479d4f17" />|


AI summary:
This pull request introduces a user logout feature and refines the UI for the "Explore" and "Favorite Projects" screens. The most significant changes are the implementation of the logout use case, integration of a reusable `ScreenHeader` component with logout functionality, and UI adjustments for better consistency and spacing.

**Authentication and Logout Functionality:**

* Added a `LogoutUseCase` class that logs out the user by calling the repository and clearing the session, and provided it via dependency injection in `AuthModule`. [[1]](diffhunk://#diff-a5e3ba5ae087eacfa7c86e1669798c4c512dcbf5efc2eb94d0c61bbe1b86799fR1-R14) [[2]](diffhunk://#diff-5d33186d949bbbc21d4f27955079d2aa202cdb7e025a14c82ff7a50aaa7ca29cR5) [[3]](diffhunk://#diff-5d33186d949bbbc21d4f27955079d2aa202cdb7e025a14c82ff7a50aaa7ca29cR54-R60)
* Updated `AuthRepository` and its implementation to support the new `logout()` method, which clears cookies and handles server errors gracefully. [[1]](diffhunk://#diff-d0405ecf2d0592b9c40cfd2be19f949587d8f45435c36b4d100ba8ae3f4b42e3R12) [[2]](diffhunk://#diff-d3487de885f746f5ffd367f69dd4723c7c77fa5415ceb7dad2fd0dc44dd7f32bR83-R94)
* Updated `SessionViewModel` to expose a `logout()` method that invokes the use case, making logout available to the UI layer. [[1]](diffhunk://#diff-eefa85e2173a5c73da929030bcec08d5bd4ab4a7161cba979486b934886e494bR5) [[2]](diffhunk://#diff-eefa85e2173a5c73da929030bcec08d5bd4ab4a7161cba979486b934886e494bR17) [[3]](diffhunk://#diff-eefa85e2173a5c73da929030bcec08d5bd4ab4a7161cba979486b934886e494bR28-R33)

**UI Component Enhancements:**

* Introduced a reusable `ScreenHeader` composable with a dropdown menu for logout, and a `ScreenTitle` composable for consistent screen titles. [[1]](diffhunk://#diff-07f71d2ccb83d1c5a21be09c99bbfb01fb8f5526a8b59f7fcdfef7ff35cd1301R1-R62) [[2]](diffhunk://#diff-f3a756c33930f0189e50e617813bc1eb7af9e05c5b429e6c749ca8096a9b5671R1-R21)
* Integrated `ScreenHeader` into both "Explore" and "Favorite Projects" screens, enabling logout from the header and improving layout consistency. [[1]](diffhunk://#diff-59a4b162e03e6196a12a5490e6a1810f55b9f68d086ac9a8e2de39401fb94317R30-R31) [[2]](diffhunk://#diff-59a4b162e03e6196a12a5490e6a1810f55b9f68d086ac9a8e2de39401fb94317R113-R133) [[3]](diffhunk://#diff-439e061234ff69d2c9c0bdaa566686efcfd3d4016f8d5f35ab0366f1fa975678R4-R15) [[4]](diffhunk://#diff-439e061234ff69d2c9c0bdaa566686efcfd3d4016f8d5f35ab0366f1fa975678L20-R38)

**UI and Layout Adjustments:**

* Adjusted paddings and spacing in "Explore" and "Favorite Projects" screens for improved visual alignment and consistency. [[1]](diffhunk://#diff-59a4b162e03e6196a12a5490e6a1810f55b9f68d086ac9a8e2de39401fb94317R113-R133) [[2]](diffhunk://#diff-59a4b162e03e6196a12a5490e6a1810f55b9f68d086ac9a8e2de39401fb94317R155) [[3]](diffhunk://#diff-d35732ec21059674fcf02fe796b7b8f75289de7f62d4ce2e0d5b1bb79037d95cL29-R29) [[4]](diffhunk://#diff-5a658ec72d04c60568192be2da05e1cbb300ed12e66ffbf1e7609e3a57e04aaaL31-R34)
* Updated section headers and removed redundant titles from empty states to avoid duplication with the new `ScreenHeader`. [[1]](diffhunk://#diff-5a658ec72d04c60568192be2da05e1cbb300ed12e66ffbf1e7609e3a57e04aaaL31-R34) [[2]](diffhunk://#diff-e853deb46c4266e23323f66a3e4185c6ee1f2c9db8403309910a46935f0b0783L25-L29)

**Preview and Testing Updates:**

* Updated UI preview functions to support the new `onLogout` callback, ensuring previews remain functional. [[1]](diffhunk://#diff-59a4b162e03e6196a12a5490e6a1810f55b9f68d086ac9a8e2de39401fb94317L172-R187) [[2]](diffhunk://#diff-59a4b162e03e6196a12a5490e6a1810f55b9f68d086ac9a8e2de39401fb94317L187-R203) [[3]](diffhunk://#diff-bb8b12c9bb62bd16d8209c9fb40d8fb8e52bfdd1d74f268e492138a99881fbe3L25-R26) [[4]](diffhunk://#diff-bb8b12c9bb62bd16d8209c9fb40d8fb8e52bfdd1d74f268e492138a99881fbe3L39-R41)

These changes collectively add logout support and improve the UI structure and maintainability across the app.