### PR TITLE
refactor/upcoming-monthly

### DIFF
--- a/app/src/main/java/com/example/twdist_android/features/upcoming/presentation/components/DayHeader.kt
+++ b/app/src/main/java/com/example/twdist_android/features/upcoming/presentation/components/DayHeader.kt
@@ -5,6 +5,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import java.time.LocalDate
@@ -14,17 +16,49 @@ import java.util.Locale
 private val headerFormatter = DateTimeFormatter.ofPattern("EEEE, d MMMM", Locale.ENGLISH)
 
 @Composable
-fun DayHeader(date: LocalDate, modifier: Modifier = Modifier) {
+fun DayHeader(
+    date: LocalDate,
+    showMonthSeparator: Boolean = false,
+    isPadding: Boolean = false,
+    modifier: Modifier = Modifier
+) {
     val today = LocalDate.now()
-    val suffix = when (date) {
-        today -> " • Today"
-        today.plusDays(1) -> " • Tomorrow"
-        else -> ""
+    val suffix = if (isPadding) {
+        ""
+    } else {
+        when (date) {
+            today -> " • Today"
+            today.plusDays(1) -> " • Tomorrow"
+            else -> ""
+        }
+    }
+    val monthSeparatorColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
+    val textColor = if (isPadding) {
+        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+    } else {
+        MaterialTheme.colorScheme.onSurface
     }
     Text(
         text = date.format(headerFormatter) + suffix,
         style = MaterialTheme.typography.titleSmall,
         fontWeight = FontWeight.SemiBold,
-        modifier = modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+        color = textColor,
+        modifier = modifier
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .then(
+                if (showMonthSeparator) {
+                    Modifier.drawBehind {
+                        val stroke = 1.dp.toPx()
+                        drawLine(
+                            color = monthSeparatorColor,
+                            start = Offset(0f, 0f),
+                            end = Offset(size.width, 0f),
+                            strokeWidth = stroke
+                        )
+                    }
+                } else {
+                    Modifier
+                }
+            )
     )
 }

--- a/app/src/main/java/com/example/twdist_android/features/upcoming/presentation/components/UpcomingTaskList.kt
+++ b/app/src/main/java/com/example/twdist_android/features/upcoming/presentation/components/UpcomingTaskList.kt
@@ -14,6 +14,12 @@ import androidx.compose.ui.unit.dp
 import com.example.twdist_android.core.ui.components.task.TaskRow
 import com.example.twdist_android.core.ui.components.task.TaskRowState
 import com.example.twdist_android.features.upcoming.presentation.model.UpcomingListItem
+import java.time.LocalDate
+
+private fun previousHeaderDate(items: List<UpcomingListItem>, beforeIndex: Int): LocalDate? =
+    items.take(beforeIndex)
+        .asReversed()
+        .firstNotNullOfOrNull { (it as? UpcomingListItem.Header)?.date }
 
 @Composable
 fun UpcomingTaskList(
@@ -32,6 +38,7 @@ fun UpcomingTaskList(
             when (item) {
                 is UpcomingListItem.Header -> "header_${item.date}"
                 is UpcomingListItem.Task -> "task_${item.state.id}"
+                is UpcomingListItem.PaddingDay -> "padding_${item.date}"
             }
         }) { idx, item ->
             when (item) {
@@ -39,7 +46,17 @@ fun UpcomingTaskList(
                     if (idx > 0) {
                         HorizontalDivider(modifier = Modifier.padding(top = 4.dp))
                     }
-                    DayHeader(date = item.date)
+                    val prevDate = previousHeaderDate(items, idx)
+                    DayHeader(
+                        date = item.date,
+                        showMonthSeparator = prevDate != null && prevDate.month != item.date.month
+                    )
+                }
+                is UpcomingListItem.PaddingDay -> {
+                    if (idx > 0) {
+                        HorizontalDivider(modifier = Modifier.padding(top = 4.dp))
+                    }
+                    DayHeader(date = item.date, isPadding = true)
                 }
                 is UpcomingListItem.Task -> TaskRow(
                     task = item.state,

--- a/app/src/main/java/com/example/twdist_android/features/upcoming/presentation/components/WeeklyCalendar.kt
+++ b/app/src/main/java/com/example/twdist_android/features/upcoming/presentation/components/WeeklyCalendar.kt
@@ -4,12 +4,15 @@ import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -18,36 +21,79 @@ import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.ui.graphics.Color
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.example.twdist_android.features.upcoming.presentation.model.UPCOMING_SCROLL_PADDING_DAYS
 import java.time.LocalDate
-import java.time.Month
-import java.time.YearMonth
 import java.time.format.TextStyle
 import java.time.temporal.WeekFields
 import java.util.Locale
 
 private val DAY_LABELS = listOf("M", "T", "W", "T", "F", "S", "S")
 
+private fun Modifier.monthChangeSeparator(
+    color: Color,
+    placement: MonthSeparatorPlacement
+): Modifier = drawBehind {
+    val stroke = 1.dp.toPx()
+    when (placement) {
+        MonthSeparatorPlacement.Above -> drawLine(
+            color = color,
+            start = Offset(0f, 0f),
+            end = Offset(size.width, 0f),
+            strokeWidth = stroke
+        )
+        is MonthSeparatorPlacement.WithinWeek -> {
+            val cellWidth = size.width / 7f
+            val boundaryX = cellWidth * placement.boundaryIndex
+            val segmentStart = boundaryX - cellWidth * 0.15f
+            val segmentEnd = boundaryX + cellWidth * 0.15f
+            val y = size.height - stroke / 2f
+            drawLine(
+                color = color,
+                start = Offset(segmentStart.coerceAtLeast(0f), y),
+                end = Offset(segmentEnd.coerceAtMost(size.width), y),
+                strokeWidth = stroke
+            )
+        }
+    }
+}
+
+private sealed interface MonthSeparatorPlacement {
+    data object Above : MonthSeparatorPlacement
+    data class WithinWeek(val boundaryIndex: Int) : MonthSeparatorPlacement
+}
+
+private fun monthBoundaryIndexInWeek(weekStart: LocalDate): Int? =
+    (0..5).firstOrNull { dayIndex ->
+        val day = weekStart.plusDays(dayIndex.toLong())
+        day.plusDays(1).month != day.month
+    }?.let { it + 1 }
+
 @Composable
 fun WeeklyCalendar(
     weekStart: LocalDate,
     visibleDate: LocalDate,
+    windowStart: LocalDate,
+    windowEnd: LocalDate,
     isExpanded: Boolean,
     onToggleExpanded: () -> Unit,
     onDayClick: (LocalDate) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val today = LocalDate.now()
+    val monthSeparatorColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
 
     val arrowRotation by animateFloatAsState(
         targetValue = if (isExpanded) 180f else 0f,
@@ -104,27 +150,44 @@ fun WeeklyCalendar(
                 weekStart = weekStart,
                 visibleDate = visibleDate,
                 today = today,
-                currentMonth = null,
+                windowStart = windowStart,
+                windowEnd = windowEnd,
+                monthSeparatorColor = monthSeparatorColor,
                 onDayClick = onDayClick
             )
         } else {
-            // Expanded: all weeks of the current month
-            val yearMonth = YearMonth.from(visibleDate)
-            val firstOfMonth = yearMonth.atDay(1)
-            val lastOfMonth = yearMonth.atEndOfMonth()
-            val gridStart = firstOfMonth.with(WeekFields.ISO.dayOfWeek(), 1)
-            val gridEnd = lastOfMonth.with(WeekFields.ISO.dayOfWeek(), 7)
+            // Expanded: weeks through window end plus scroll padding (non-selectable tail days).
+            val gridStart = windowStart.with(WeekFields.ISO.dayOfWeek(), 1)
+            val scrollPaddingEnd = windowEnd.plusDays(UPCOMING_SCROLL_PADDING_DAYS.toLong())
+            val gridEnd = scrollPaddingEnd.with(WeekFields.ISO.dayOfWeek(), 7)
+            val scrollState = rememberScrollState()
 
-            var rowStart = gridStart
-            while (!rowStart.isAfter(gridEnd)) {
-                CalendarWeekRow(
-                    weekStart = rowStart,
-                    visibleDate = visibleDate,
-                    today = today,
-                    currentMonth = yearMonth.month,
-                    onDayClick = onDayClick
-                )
-                rowStart = rowStart.plusWeeks(1)
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 280.dp)
+                    .verticalScroll(scrollState)
+            ) {
+                var rowStart = gridStart
+                var previousWeekStart: LocalDate? = null
+                while (!rowStart.isAfter(gridEnd)) {
+                    val showSeparatorAbove = previousWeekStart != null &&
+                        previousWeekStart.plusDays(6).month != rowStart.month
+                    val withinWeekBoundary = monthBoundaryIndexInWeek(rowStart)
+                    CalendarWeekRow(
+                        weekStart = rowStart,
+                        visibleDate = visibleDate,
+                        today = today,
+                        windowStart = windowStart,
+                        windowEnd = windowEnd,
+                        monthSeparatorColor = monthSeparatorColor,
+                        separatorAbove = showSeparatorAbove,
+                        withinWeekBoundaryIndex = withinWeekBoundary,
+                        onDayClick = onDayClick
+                    )
+                    previousWeekStart = rowStart
+                    rowStart = rowStart.plusWeeks(1)
+                }
             }
         }
     }
@@ -135,19 +198,33 @@ private fun CalendarWeekRow(
     weekStart: LocalDate,
     visibleDate: LocalDate,
     today: LocalDate,
-    currentMonth: Month?,
+    windowStart: LocalDate,
+    windowEnd: LocalDate,
+    monthSeparatorColor: Color,
+    separatorAbove: Boolean = false,
+    withinWeekBoundaryIndex: Int? = null,
     onDayClick: (LocalDate) -> Unit
 ) {
+    val rowSeparatorModifier = when {
+        separatorAbove -> Modifier.monthChangeSeparator(monthSeparatorColor, MonthSeparatorPlacement.Above)
+        withinWeekBoundaryIndex != null -> Modifier.monthChangeSeparator(
+            monthSeparatorColor,
+            MonthSeparatorPlacement.WithinWeek(withinWeekBoundaryIndex)
+        )
+        else -> Modifier
+    }
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .then(rowSeparatorModifier),
         horizontalArrangement = Arrangement.SpaceEvenly
     ) {
         for (i in 0..6) {
             val day = weekStart.plusDays(i.toLong())
             val isHighlighted = day == visibleDate
-            val isOutOfMonth = currentMonth != null && day.month != currentMonth
+            val isOutOfWindow = day.isBefore(windowStart) || day.isAfter(windowEnd)
             val isPast = day.isBefore(today)
-            val isTappable = !isPast && !isOutOfMonth
+            val isTappable = !isPast && !isOutOfWindow
 
             // Outer Box: fixed height so rows never resize when the highlight circle
             // appears or disappears on this cell.
@@ -165,7 +242,7 @@ private fun CalendarWeekRow(
                         .size(32.dp)
                         .clip(CircleShape)
                         .background(
-                            if (isHighlighted && !isOutOfMonth) MaterialTheme.colorScheme.primary
+                            if (isHighlighted && !isOutOfWindow) MaterialTheme.colorScheme.primary
                             else Color.Transparent
                         )
                         .then(if (isTappable) Modifier.clickable { onDayClick(day) } else Modifier)
@@ -174,8 +251,8 @@ private fun CalendarWeekRow(
                         text = day.dayOfMonth.toString(),
                         style = MaterialTheme.typography.bodyMedium,
                         color = when {
-                            isHighlighted && !isOutOfMonth -> MaterialTheme.colorScheme.onPrimary
-                            isOutOfMonth || isPast -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+                            isHighlighted && !isOutOfWindow -> MaterialTheme.colorScheme.onPrimary
+                            isOutOfWindow || isPast -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
                             else -> MaterialTheme.colorScheme.onSurface
                         },
                         textAlign = TextAlign.Center
@@ -193,6 +270,8 @@ private fun WeeklyCalendarCollapsedPreview() {
     WeeklyCalendar(
         weekStart = today.with(WeekFields.ISO.dayOfWeek(), 1),
         visibleDate = today,
+        windowStart = today,
+        windowEnd = today.plusMonths(1),
         isExpanded = false,
         onToggleExpanded = {},
         onDayClick = {}
@@ -206,6 +285,8 @@ private fun WeeklyCalendarExpandedPreview() {
     WeeklyCalendar(
         weekStart = today.with(WeekFields.ISO.dayOfWeek(), 1),
         visibleDate = today,
+        windowStart = today,
+        windowEnd = today.plusMonths(1),
         isExpanded = true,
         onToggleExpanded = {},
         onDayClick = {}

--- a/app/src/main/java/com/example/twdist_android/features/upcoming/presentation/model/UpcomingListItem.kt
+++ b/app/src/main/java/com/example/twdist_android/features/upcoming/presentation/model/UpcomingListItem.kt
@@ -3,7 +3,11 @@ package com.example.twdist_android.features.upcoming.presentation.model
 import com.example.twdist_android.core.ui.components.task.TaskRowState
 import java.time.LocalDate
 
+/** Days shown after [windowEnd] so the list can scroll the last selectable dates into reach. */
+const val UPCOMING_SCROLL_PADDING_DAYS = 6
+
 sealed interface UpcomingListItem {
     data class Header(val date: LocalDate) : UpcomingListItem
     data class Task(val state: TaskRowState, val date: LocalDate) : UpcomingListItem
+    data class PaddingDay(val date: LocalDate) : UpcomingListItem
 }

--- a/app/src/main/java/com/example/twdist_android/features/upcoming/presentation/model/UpcomingUiState.kt
+++ b/app/src/main/java/com/example/twdist_android/features/upcoming/presentation/model/UpcomingUiState.kt
@@ -8,5 +8,7 @@ data class UpcomingUiState(
     val error: String? = null,
     val items: List<UpcomingListItem> = emptyList(),
     val visibleDate: LocalDate = LocalDate.now(),
-    val weekStart: LocalDate = LocalDate.now().with(WeekFields.ISO.dayOfWeek(), 1)
+    val weekStart: LocalDate = LocalDate.now().with(WeekFields.ISO.dayOfWeek(), 1),
+    val windowStart: LocalDate = LocalDate.now(),
+    val windowEnd: LocalDate = LocalDate.now().plusMonths(1)
 )

--- a/app/src/main/java/com/example/twdist_android/features/upcoming/presentation/screens/UpcomingScreen.kt
+++ b/app/src/main/java/com/example/twdist_android/features/upcoming/presentation/screens/UpcomingScreen.kt
@@ -83,6 +83,7 @@ fun UpcomingScreen(
                 when (item) {
                     is UpcomingListItem.Header -> item.date
                     is UpcomingListItem.Task -> item.date
+                    is UpcomingListItem.PaddingDay -> null
                 }
             }
         }
@@ -157,6 +158,8 @@ fun UpcomingScreenContent(
             WeeklyCalendar(
                 weekStart = uiState.weekStart,
                 visibleDate = uiState.visibleDate,
+                windowStart = uiState.windowStart,
+                windowEnd = uiState.windowEnd,
                 isExpanded = calendarExpanded,
                 onToggleExpanded = onToggleCalendarExpanded,
                 onDayClick = onDayClick

--- a/app/src/main/java/com/example/twdist_android/features/upcoming/presentation/viewmodel/UpcomingViewModel.kt
+++ b/app/src/main/java/com/example/twdist_android/features/upcoming/presentation/viewmodel/UpcomingViewModel.kt
@@ -8,6 +8,7 @@ import com.example.twdist_android.features.upcoming.application.usecases.GetUpco
 import com.example.twdist_android.features.upcoming.application.usecases.RefreshUpcomingTasksUseCase
 import com.example.twdist_android.features.upcoming.application.usecases.UndoCompleteUpcomingTaskUseCase
 import com.example.twdist_android.features.upcoming.domain.model.UpcomingTask
+import com.example.twdist_android.features.upcoming.presentation.model.UPCOMING_SCROLL_PADDING_DAYS
 import com.example.twdist_android.features.upcoming.presentation.model.UpcomingListItem
 import com.example.twdist_android.features.upcoming.presentation.model.UpcomingUiEvent
 import com.example.twdist_android.features.upcoming.presentation.model.UpcomingUiState
@@ -16,10 +17,10 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.time.LocalDate
-import java.time.temporal.TemporalAdjusters
 import java.time.temporal.WeekFields
 import javax.inject.Inject
 
@@ -37,21 +38,37 @@ class UpcomingViewModel @Inject constructor(
     private val _events = MutableSharedFlow<UpcomingUiEvent>()
     val events: SharedFlow<UpcomingUiEvent> = _events
 
-    private val today: LocalDate = LocalDate.now()
-    private val endOfMonth: LocalDate = today.with(TemporalAdjusters.lastDayOfMonth())
+    private var observationJob: Job? = null
+    private var observedRange: Pair<LocalDate, LocalDate>? = null
 
     init {
-        viewModelScope.launch {
-            getUpcomingTasksUseCase(from = today, to = endOfMonth).collect { tasks ->
+        observeUpcomingTasksIfNeeded()
+        refreshTasks(showLoading = true)
+    }
+
+    private fun rollingWindow(): Pair<LocalDate, LocalDate> {
+        val from = LocalDate.now()
+        return from to from.plusMonths(1)
+    }
+
+    private fun observeUpcomingTasksIfNeeded() {
+        val (from, to) = rollingWindow()
+        if (observedRange == from to to) return
+        observedRange = from to to
+        observationJob?.cancel()
+        observationJob = viewModelScope.launch {
+            getUpcomingTasksUseCase(from = from, to = to).collect { tasks ->
+                val (currentFrom, currentTo) = rollingWindow()
                 _uiState.update { state ->
                     state.copy(
                         isLoading = false,
-                        items = buildListItems(today, endOfMonth, tasks)
+                        items = buildListItems(currentFrom, currentTo, tasks),
+                        windowStart = currentFrom,
+                        windowEnd = currentTo
                     )
                 }
             }
         }
-        refreshTasks(showLoading = true)
     }
 
     /**
@@ -60,10 +77,12 @@ class UpcomingViewModel @Inject constructor(
      */
     fun refreshTasks(showLoading: Boolean = true) {
         viewModelScope.launch {
+            observeUpcomingTasksIfNeeded()
+            val (from, to) = rollingWindow()
             if (showLoading) {
                 _uiState.update { it.copy(isLoading = true, error = null) }
             }
-            refreshUpcomingTasksUseCase(from = today, to = endOfMonth)
+            refreshUpcomingTasksUseCase(from = from, to = to)
                 .onSuccess {
                     // Room Flow does not always re-emit (e.g. empty API body -> no DAO write): clear spinner anyway.
                     if (showLoading) {
@@ -144,6 +163,9 @@ class UpcomingViewModel @Inject constructor(
                 )
             }
             current = current.plusDays(1)
+        }
+        for (offset in 1..UPCOMING_SCROLL_PADDING_DAYS) {
+            result.add(UpcomingListItem.PaddingDay(to.plusDays(offset.toLong())))
         }
         return result
     }

--- a/app/src/test/java/com/example/twdist_android/features/upcoming/presentation/viewmodel/UpcomingViewModelTest.kt
+++ b/app/src/test/java/com/example/twdist_android/features/upcoming/presentation/viewmodel/UpcomingViewModelTest.kt
@@ -8,6 +8,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
@@ -39,6 +40,25 @@ class UpcomingViewModelTest {
     @After
     fun tearDown() {
         Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `refresh uses rolling one month window from today`() = runTest {
+        val fromSlot = slot<LocalDate>()
+        val toSlot = slot<LocalDate>()
+        coEvery { refreshUpcomingTasksUseCase(capture(fromSlot), capture(toSlot)) } returns Result.success(Unit)
+
+        UpcomingViewModel(
+            getUpcomingTasksUseCase,
+            refreshUpcomingTasksUseCase,
+            completeUpcomingTaskUseCase,
+            undoCompleteUpcomingTaskUseCase
+        )
+        advanceUntilIdle()
+
+        val today = LocalDate.now()
+        assertEquals(today, fromSlot.captured)
+        assertEquals(today.plusMonths(1), toSlot.captured)
     }
 
     @Test


### PR DESCRIPTION
In the Upcoming section, the rolling period of one month from today’s date (e.g. May 21 to June 21) has been used instead of the fixed calendar month ending, and this period changes according to the screen refresh or resume. In addition to the drop-down calendar view and date list have been given borders indicating month ends.

Ai summary:
This pull request enhances the Upcoming screen's calendar and list experience by introducing a rolling date window, improved month separation visuals, and scroll padding for smoother navigation. The changes ensure that both the calendar and task list clearly indicate month boundaries, allow scrolling beyond the last selectable date, and keep the UI state consistent with the visible date range.

**Calendar and Month Boundary Improvements**
- Added visual month separators to both the calendar view and the day headers in the task list, making it easier for users to see where months change. [[1]](diffhunk://#diff-1fe8e90a7a91275e78cb2b782f556933be7ad2b6d5f7278ab86b944a6aff93bfL21-R96) [[2]](diffhunk://#diff-f36f80dff6ac960244b8d9c825dcf94d8a6fe1aff907988f43e148fb1df412f6L17-R62)
- Refactored the calendar to support a rolling window (current day to one month ahead) and to visually indicate month transitions within and between weeks. [[1]](diffhunk://#diff-1fe8e90a7a91275e78cb2b782f556933be7ad2b6d5f7278ab86b944a6aff93bfL107-R227) [[2]](diffhunk://#diff-1fe8e90a7a91275e78cb2b782f556933be7ad2b6d5f7278ab86b944a6aff93bfL168-R245) [[3]](diffhunk://#diff-1fe8e90a7a91275e78cb2b782f556933be7ad2b6d5f7278ab86b944a6aff93bfL177-R255)

**List and Scroll Padding Enhancements**
- Introduced `UpcomingListItem.PaddingDay` and a configurable scroll padding (`UPCOMING_SCROLL_PADDING_DAYS`) so users can scroll the list beyond the last selectable date, ensuring better reachability and consistent UI. [[1]](diffhunk://#diff-c32a535f06a34582612bfe41bf83e783dc51b51c48a0cab00218cd0e666cd353R6-R12) [[2]](diffhunk://#diff-8c19477466b6e865b14020cbf61a1946c65c931fff9c39b061d7dbd2d159fa45R41-R59)

**State and ViewModel Updates**
- Updated `UpcomingUiState` to include `windowStart` and `windowEnd` fields, and refactored the `UpcomingViewModel` to keep the observed date range in sync with the rolling window. This ensures that the UI always reflects the current and upcoming dates. [[1]](diffhunk://#diff-249a8295657fd4f46b74e476842d98d214ec2ceb633ce8aac03c7fed2a63644eL11-R13) [[2]](diffhunk://#diff-7c611ae2ab3fa2338a20af4dbd236a0614b99e603e91ba236e6fd05808867f53L40-L54)

**Component and API Adjustments**
- Updated `WeeklyCalendar` and related composables to accept the new window parameters and handle the new month separator logic. [[1]](diffhunk://#diff-1fe8e90a7a91275e78cb2b782f556933be7ad2b6d5f7278ab86b944a6aff93bfR273-R274) [[2]](diffhunk://#diff-1fe8e90a7a91275e78cb2b782f556933be7ad2b6d5f7278ab86b944a6aff93bfR288-R289) [[3]](diffhunk://#diff-0d6529621a5df7a04a7de276bb920e8d87548a96886f12011cf20efe12a85f8aR161-R162)
- Adjusted list keying and rendering to support the new `PaddingDay` item type and improved header logic. [[1]](diffhunk://#diff-8c19477466b6e865b14020cbf61a1946c65c931fff9c39b061d7dbd2d159fa45R41-R59) [[2]](diffhunk://#diff-0d6529621a5df7a04a7de276bb920e8d87548a96886f12011cf20efe12a85f8aR86)

These changes collectively improve the usability and clarity of the Upcoming feature's calendar and list views, especially around month transitions and scrolling behavior.