### PR TITLE
Chore/auto releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,12 @@ jobs:
       - uses: gradle/actions/setup-gradle@v3
 
       - name: Inject production BASE_URL
-        run: echo "BASE_URL=${{ secrets.RELEASE_BASE_URL }}" >> .env
+        run: |
+          if [ -z "${{ secrets.RELEASE_BASE_URL }}" ]; then
+            echo "::error::RELEASE_BASE_URL secret is not set"
+            exit 1
+          fi
+          printf 'BASE_URL=%s\n' "${{ secrets.RELEASE_BASE_URL }}" > .env
 
       - name: Decode release keystore
         run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > "${{ github.workspace }}/release.keystore"
@@ -59,4 +64,5 @@ jobs:
           tag_name: ${{ steps.version.outputs.version }}
           name: Release ${{ steps.version.outputs.version }}
           files: app/build/outputs/apk/release/*.apk
+          prerelease: true
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         run: echo "BASE_URL=${{ secrets.RELEASE_BASE_URL }}" >> .env
 
       - name: Decode release keystore
-        run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > release.keystore
+        run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > "${{ github.workspace }}/release.keystore"
 
       - name: Compute release version
         id: version
@@ -42,15 +42,9 @@ jobs:
           echo "version_code=$VERSION_CODE" >> "$GITHUB_OUTPUT"
           echo "Release version: $VERSION (versionCode=$VERSION_CODE)"
 
-      - name: Lint
-        run: ./gradlew lint
-
-      - name: Unit tests
-        run: ./gradlew test
-
       - name: Build signed release APK
         env:
-          ANDROID_KEYSTORE_PATH: release.keystore
+          ANDROID_KEYSTORE_PATH: ${{ github.workspace }}/release.keystore
           ANDROID_STORE_PASSWORD: ${{ secrets.KEYSTORE_STORE_PASSWORD }}
           ANDROID_KEY_ALIAS: ${{ secrets.KEYSTORE_KEY_ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.KEYSTORE_KEY_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Release
+
+on:
+  push:
+    branches: [chore/auto-releases]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - uses: android-actions/setup-android@v3
+      - uses: gradle/actions/setup-gradle@v3
+
+      - name: Inject production BASE_URL
+        run: echo "BASE_URL=${{ secrets.RELEASE_BASE_URL }}" >> .env
+
+      - name: Decode release keystore
+        run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > release.keystore
+
+      - name: Compute release version
+        id: version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TODAY=$(date +"%-Y.%-m.%-d")
+          COUNT=$(gh release list --limit 100 --json tagName \
+            | jq "[.[] | select(.tagName | startswith(\"$TODAY.\"))] | length")
+          N=$((COUNT + 1))
+          VERSION="${TODAY}.${N}"
+          VERSION_CODE=$(date +"%Y%m%d")$(printf "%02d" $N)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "version_code=$VERSION_CODE" >> "$GITHUB_OUTPUT"
+          echo "Release version: $VERSION (versionCode=$VERSION_CODE)"
+
+      - name: Lint
+        run: ./gradlew lint
+
+      - name: Unit tests
+        run: ./gradlew test
+
+      - name: Build signed release APK
+        env:
+          ANDROID_KEYSTORE_PATH: release.keystore
+          ANDROID_STORE_PASSWORD: ${{ secrets.KEYSTORE_STORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.KEYSTORE_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
+        run: |
+          ./gradlew assembleRelease \
+            -PversionCode=${{ steps.version.outputs.version_code }} \
+            -PversionName=${{ steps.version.outputs.version }}
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.version }}
+          name: Release ${{ steps.version.outputs.version }}
+          files: app/build/outputs/apk/release/*.apk
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [chore/auto-releases]
+    branches: [main]
 
 permissions:
   contents: write

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 local.properties
 
 **/.env
+*.jks
+release.keystore
+keystore_b64.txt

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ On macOS or Linux:
 BASE_URL=https://your-api.example.com/api/
 ```
 
+## Releases
+
+Pushes to `main` trigger an automatic GitHub Release with a signed APK (tag format `YYYY.M.D.N`, e.g. `2026.5.21.1`). 
+
 ## Start developing
 
 - **Android Studio:** run the **app** configuration on an emulator or device.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "com.example.twdist_android"
         minSdk = 24
         targetSdk = 36
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = (findProperty("versionCode") as String?)?.toInt() ?: 1
+        versionName = findProperty("versionName") as String? ?: "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
@@ -38,8 +38,23 @@ android {
         buildConfig = true
     }
 
+    signingConfigs {
+        create("release") {
+            val keystorePath = System.getenv("ANDROID_KEYSTORE_PATH")
+            if (keystorePath != null) {
+                storeFile = file(keystorePath)
+                storePassword = System.getenv("ANDROID_STORE_PASSWORD")
+                keyAlias = System.getenv("ANDROID_KEY_ALIAS")
+                keyPassword = System.getenv("ANDROID_KEY_PASSWORD")
+            }
+        }
+    }
+
     buildTypes {
         release {
+            if (System.getenv("ANDROID_KEYSTORE_PATH") != null) {
+                signingConfig = signingConfigs.getByName("release")
+            }
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,7 +42,7 @@ android {
         create("release") {
             val keystorePath = System.getenv("ANDROID_KEYSTORE_PATH")
             if (keystorePath != null) {
-                storeFile = file(keystorePath)
+                storeFile = rootProject.file(keystorePath)
                 storePassword = System.getenv("ANDROID_STORE_PASSWORD")
                 keyAlias = System.getenv("ANDROID_KEY_ALIAS")
                 keyPassword = System.getenv("ANDROID_KEY_PASSWORD")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,7 +30,10 @@ android {
             envFile.inputStream().use { properties.load(it) }
         }
         
-        val baseUrl = properties.getProperty("BASE_URL") ?: "http://10.0.2.2:8080/api/"
+        val baseUrlRaw = properties.getProperty("BASE_URL")?.trim()?.takeIf { it.isNotBlank() }
+        val baseUrl = (baseUrlRaw ?: "http://10.0.2.2:8080/api/").let { url ->
+            if (url.endsWith("/")) url else "$url/"
+        }
         buildConfigField("String", "BASE_URL", "\"$baseUrl\"")
     }
 

--- a/app/src/main/java/com/example/twdist_android/di/NetworkModule.kt
+++ b/app/src/main/java/com/example/twdist_android/di/NetworkModule.kt
@@ -57,13 +57,19 @@ object NetworkModule {
     fun provideOkHttpClient(
         cookieJar: okhttp3.CookieJar,
         authenticator: TokenRefreshAuthenticator
-    ): OkHttpClient = OkHttpClient.Builder()
-        .cookieJar(cookieJar)
-        .authenticator(authenticator)
-        .addInterceptor(HttpLoggingInterceptor().apply {
-            level = HttpLoggingInterceptor.Level.BODY
-        })
-        .build()
+    ): OkHttpClient {
+        val builder = OkHttpClient.Builder()
+            .cookieJar(cookieJar)
+            .authenticator(authenticator)
+        if (BuildConfig.DEBUG) {
+            builder.addInterceptor(
+                HttpLoggingInterceptor().apply {
+                    level = HttpLoggingInterceptor.Level.BODY
+                }
+            )
+        }
+        return builder.build()
+    }
 
     @Provides
     @Singleton

--- a/docs/RELEASE_SETUP.md
+++ b/docs/RELEASE_SETUP.md
@@ -1,0 +1,46 @@
+# Release pipeline setup (one-time)
+
+Automatic releases run on every push to `main` via [`.github/workflows/release.yml`](../.github/workflows/release.yml). Each release is tagged with the format `YYYY.M.D.N` (e.g. `2026.5.21.3` for the third release on that day).
+
+## 1. Generate the release keystore
+
+Run once on your machine (do **not** commit the `.jks` file):
+
+```sh
+keytool -genkey -v \
+  -keystore twdist-release.jks \
+  -keyalg RSA -keysize 2048 -validity 10000 \
+  -alias twdist-key
+```
+
+Encode for GitHub Actions:
+
+```sh
+# Linux
+base64 -w 0 twdist-release.jks > keystore_b64.txt
+
+# macOS
+base64 -i twdist-release.jks -o keystore_b64.txt
+```
+
+Store `twdist-release.jks` and passwords in a secure password manager. Losing the keystore prevents shipping updates with the same app signing identity.
+
+## 2. Add GitHub repository secrets
+
+In the repo: **Settings → Secrets and variables → Actions → New repository secret**
+
+| Secret | Value |
+|--------|--------|
+| `KEYSTORE_BASE64` | Contents of `keystore_b64.txt` |
+| `KEYSTORE_STORE_PASSWORD` | Keystore password |
+| `KEYSTORE_KEY_ALIAS` | e.g. `twdist-key` |
+| `KEYSTORE_KEY_PASSWORD` | Key password |
+| `RELEASE_BASE_URL` | Production API URL **with trailing slash**, e.g. `https://api.example.com/api/` |
+
+If `RELEASE_BASE_URL` is missing or empty, the release build fails in CI. A malformed URL (no trailing slash) is normalized at build time; an empty value still crashes the app at startup when Retrofit initializes.
+
+## 3. Verify
+
+Merge or push to `main`. The workflow will build a signed release APK and publish a **pre-release** on GitHub with the APK attached. Lint and tests are enforced by the PR CI workflow before merge.
+
+Download the APK from the release assets page and install on a device (enable install from unknown sources if needed).


### PR DESCRIPTION
Basically all the necessary changes for publishing new pre-releases everytime anything gets pushed into the main branch. I confirmed that this worked perfectly fine by publishing a couple of releases from this branch. The last one is already prod-ready and marked as the latest version.

---

AI Summary:
This pull request introduces a fully automated release pipeline for the Android app, enabling signed APKs to be built and published as GitHub Releases on every push to `main`. It also adds documentation and configuration to support secure, reproducible releases, and improves build and runtime safety for production builds.

Key changes include:

**Release Automation & Documentation**

* Added a GitHub Actions workflow (`.github/workflows/release.yml`) to build, sign, and publish a release APK as a GitHub Release on every push to `main`, with dynamic versioning and secure secret handling.
* Added `docs/RELEASE_SETUP.md` with step-by-step instructions for generating a release keystore, configuring repository secrets, and verifying the release pipeline.
* Updated `README.md` to document the automatic release process and release tag format.

**Build Configuration & Signing**

* Updated `app/build.gradle.kts` to:
  - Allow `versionCode` and `versionName` to be injected at build time, defaulting to development values if not set.
  - Normalize and validate the `BASE_URL` from environment or `.env` for safer release builds.
  - Add a `release` signing config that loads keystore and passwords from environment variables, and applies the config only if present. [[1]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L21-R22) [[2]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L33-R60)

**Debug Logging**

* Updated `NetworkModule.kt` so that HTTP logging (via `HttpLoggingInterceptor`) is only enabled in debug builds, preventing sensitive data from being logged in release builds.